### PR TITLE
add more clear HDF5 error message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,21 @@ endif()
 
 # HDF5
 if(PHOEBUS_ENABLE_HDF5)
+  set(HDF5_PREFER_PARALLEL ${PHOEBUS_ENABLE_MPI})
+  find_package(HDF5 COMPONENTS C)
+  if (NOT HDF5_FOUND)
+    message(FATAL_ERROR "HDF5 is required but couldn't be found. "
+      "If you want to build Phoebus without HDF5, please rerun "
+      "CMake with -DPHOEBUS_ENABLE_HDF5=OFF")
+  endif()
+  if (PHOEBUS_ENABLE_MPI AND (NOT HDF5_IS_PARALLEL))
+    message(FATAL_ERROR "Both MPI and HDF5 are enabled "
+      "but only a serial version of HDF5 was found. Please install "
+      "a parallel version of HDF5 (or point CMake to it by adding its path "
+      "to the CMAKE_PREFIX_PATH environment variable), or disable either MPI "
+      "or HDF5 by rerunning CMake with -DPHOEBUS_ENABLE_MPI=OFF or "
+      "-DPHOEBUS_ENABLE_HDF5=OFF".)
+  endif()
   set(SINGULARITY_USE_HDF5 ON CACHE BOOL "" FORCE)
   set(PARTHENON_DISABLE_HDF5 OFF CACHE BOOL "" FORCE)
 else()
@@ -119,8 +134,7 @@ endif()
 if(PHOEBUS_ENABLE_OPENMP)
   find_package(OpenMP COMPONENTS CXX)
 else()
-  set(PARTHENON_DISABLE_OPENM
-  P ON CACHE BOOL "" FORCE)
+  set(PARTHENON_DISABLE_OPENMP ON CACHE BOOL "" FORCE)
 endif()
 
 # TODO(JMM): For some reason, order still maters for including


### PR DESCRIPTION
Resolves #9 by finding `hdf5` at the Phoebus level in the build system and providing a useful error message. Unfortunately, phoebus needs to know whether or not hdf5 is enabled because it needs to set the same for singularity.

These issues may disappear if we move to spackages for, e.g., singurity.