### PR TITLE
Fix No-MPI Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,13 @@ else()
    set(PRINT_RHS 0)
 endif()
 
+# MPI parallel
+if (PHOEBUS_ENABLE_MPI)
+  set(MPI_OPTION MPI_PARALLEL)
+else ()
+  set(MPI_OPTION NOT_MPI_PARALLEL)
+endif()
+
 # Phoebus src
 message("\nConfiguring src")
 add_subdirectory(src)

--- a/src/compile_constants.hpp.in
+++ b/src/compile_constants.hpp.in
@@ -22,4 +22,9 @@
 
 #define PRINT_RHS @PRINT_RHS@
 
+// MPI paralellization (MPI_PARALLEL or NOT_MPI_PARALLEL)
+// TODO(BRR) This may be unnecessary in the future once swarms are more self-
+// contained in parthenon
+#define @MPI_OPTION@
+
 #endif //COMPILE_CONSTANTS_HPP_

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -535,6 +535,7 @@ TaskStatus MonteCarloStopCommunication(const BlockList_t &blocks) {
 TaskStatus InitializeCommunicationMesh(const std::string swarmName,
                                        const BlockList_t &blocks) {
   // Boundary transfers on same MPI proc are blocking
+#ifdef MPI_PARALLEL
   for (auto &block : blocks) {
     auto swarm = block->swarm_data.Get()->Get(swarmName);
     for (int n = 0; n < block->pbval->nneighbor; n++) {
@@ -542,6 +543,7 @@ TaskStatus InitializeCommunicationMesh(const std::string swarmName,
       swarm->vbswarm->bd_var_.req_send[nb.bufid] = MPI_REQUEST_NULL;
     }
   }
+#endif // MPI_PARALLEL
 
   for (auto &block : blocks) {
     auto &pmb = block;


### PR DESCRIPTION
I forgot to guard some radiation code with an `MPI_PARALLEL` which broke builds when MPI is disabled. Here is the fix. Thanks to @maxpkatz for identifying this. 

In the long run we may not need this -- there is already a PR underway to at least partially get this logic into the `Swarm` class itself, and `parthenon` already handles the `MPI_PARALLEL` guards correctly. 