### PR TITLE
Remove unnecessary code from no MPI build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,13 +178,6 @@ else()
    set(PRINT_RHS 0)
 endif()
 
-# MPI parallel
-if (PHOEBUS_ENABLE_MPI)
-  set(MPI_OPTION MPI_PARALLEL)
-else ()
-  set(MPI_OPTION NOT_MPI_PARALLEL)
-endif()
-
 # Phoebus src
 message("\nConfiguring src")
 add_subdirectory(src)

--- a/src/compile_constants.hpp.in
+++ b/src/compile_constants.hpp.in
@@ -22,9 +22,4 @@
 
 #define PRINT_RHS @PRINT_RHS@
 
-// MPI paralellization (MPI_PARALLEL or NOT_MPI_PARALLEL)
-// TODO(BRR) This may be unnecessary in the future once swarms are more self-
-// contained in parthenon
-#define @MPI_OPTION@
-
 #endif //COMPILE_CONSTANTS_HPP_


### PR DESCRIPTION
As @Yurlungur pointed out to me I don't need to recreate the parthenon logic that defines either `MPI_PARALLEL` or `NO_MPI_PARALLEL`. This PR cleans up that extra code I added in. Code still compiles and runs without MPI. 