### PR TITLE
b0 bugfix

### DIFF
--- a/src/fluid/tmunu.hpp
+++ b/src/fluid/tmunu.hpp
@@ -127,8 +127,7 @@ private:
       b[l] = iW * (b_(l, std::forward<Args>(args)...) + alpha * b[0] * u[l]);
     }
 
-    b[0] *= alpha;
-    bsq = (Bsq + b[0] * b[0]) * iW * iW;
+    bsq = (Bsq + alpha * alpha * b[0] * b[0]) * iW * iW;
   }
 
   Pack pack_;


### PR DESCRIPTION
There was an extra `alpha` in b^0 inside a function in the Tmunu calculation (used for calculating geometric sources) that was then being used in the actual expression for Tmunu outside of that function. With this extra factor removed, the torus looks much better (here at 2000M):

![image](https://user-images.githubusercontent.com/2207688/148666795-60ec2d9e-6499-4f1f-a42b-e6fa51cebdce.png)
