### PR TITLE
disable stellar collapse code when HDF5 disabled. Resolves #76

### DIFF
--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     
     sie_min = eos_sc.sieMin()/sie_unit;
     sie_max = eos_sc.sieMax()/sie_unit;
-    T_min = seos_sc.TMin()/T_unit;
+    T_min = eos_sc.TMin()/T_unit;
     T_max = eos_sc.TMax()/T_unit;
     rho_min = eos_sc.rhoMin()/rho_unit;
     rho_max = eos_sc.rhoMax()/rho_unit;


### PR DESCRIPTION
The recent stellar collapse EOS update caused exposed some machinery that should be disabled when HDF5 is disabled, as discovered by @jeffhammond . This should disable them appropriately.