### PR TITLE
Add timestep controls to the monopole gravity solver

### DIFF
--- a/inputs/tov.pin
+++ b/inputs/tov.pin
@@ -135,10 +135,10 @@ run_n_times = -1
 # dtfac is for time step control. 0 < dtfac <= 1.
 # time step will be <= dtfac*(time rate of change of lapse)
 dtfac = 0.9
-# dtwarn tries to estimate if first-order operator split is sufficiently accurate.
+# warn_on_dt tries to estimate if first-order operator split is sufficiently accurate.
 # Compares (dalpha/dt) computed analytically with numerical difference
 # between two subcycles. Warns if difference is larger than dtwarn_eps
-dtwarn = false
+warn_on_dt = false
 dtwarn_eps = 1e-5
 
 <tov>

--- a/inputs/tov.pin
+++ b/inputs/tov.pin
@@ -132,6 +132,14 @@ force_static = false
 # Runs the first n subcycles. Then freezes. Source terms are not disabled.
 # -1 means it's always run.
 run_n_times = -1
+# dtfac is for time step control. 0 < dtfac <= 1.
+# time step will be <= dtfac*(time rate of change of lapse)
+dtfac = 0.9
+# dtwarn tries to estimate if first-order operator split is sufficiently accurate.
+# Compares (dalpha/dt) computed analytically with numerical difference
+# between two subcycles. Warns if difference is larger than dtwarn_eps
+dtwarn = false
+dtwarn_eps = 1e-5
 
 <tov>
 enabled = true

--- a/src/monopole_gr/monopole_gr.cpp
+++ b/src/monopole_gr/monopole_gr.cpp
@@ -528,7 +528,8 @@ TaskStatus CheckRateOfChange(StateDescriptor *pkg, Real dt) {
     if (err > dtwarn_eps) {
       std::cerr
           << "\tWarning! (alpha^i+1 - alpha^i)/dt is very different from dalpha/dt.\n"
-          << "\t\tTolerance set to " << dtwarn_eps << std::endl;
+          << "\t\tTolerance set to " << dtwarn_eps << " but value is " << err << "."
+          << std::endl;
     }
   }
   return TaskStatus::complete;

--- a/src/monopole_gr/monopole_gr.cpp
+++ b/src/monopole_gr/monopole_gr.cpp
@@ -64,8 +64,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // Time step control. Equivalent to CFL
   // Empirical. controls
   Real dtfac = pin->GetOrAddReal("monopole_gr", "dtfac", 0.9);
-  PARTHENON_REQUIRE_THROWS(0 < dtfac && dtfac <= 1.,
-                           "dtfac must be between 0 and 1");
+  PARTHENON_REQUIRE_THROWS(0 < dtfac && dtfac <= 1., "dtfac must be between 0 and 1");
   params.Add("dtfac", dtfac);
 
   // Warn if the change in lapse is too different from dalpha/dt

--- a/src/monopole_gr/monopole_gr.cpp
+++ b/src/monopole_gr/monopole_gr.cpp
@@ -15,10 +15,14 @@
 #include <cmath>
 #include <cstdio>
 #include <memory>
+#include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
+#include <utility>
 
 // Parthenon
+#include <globals.hpp>
 #include <kokkos_abstraction.hpp>
 #include <parthenon/driver.hpp>
 #include <parthenon/package.hpp>
@@ -56,6 +60,17 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("run_n_times", run_n_times);
   int nth_call = 0;
   params.Add("nth_call", nth_call, true); // mutable
+
+  // Time step control. Equivalent to CFL
+  // Empirical. controls 
+  Real dtfac = pin->GetOrAddReal("monopole_gr", "dtfac", 0.9);
+  params.Add("dtfac", dtfac);
+
+  // Warn if the change in lapse is too different from dalpha/dt
+  bool dtwarn = pin->GetOrAddBoolean("monopole_gr", "warn_on_dt", false);
+  Real dtwarn_eps = pin->GetOrAddReal("monopole_gr", "dtwarn_eps", 1e-5);
+  params.Add("dtwarn", dtwarn);
+  params.Add("dtwarn_eps", dtwarn_eps);
 
   // Points
   int npoints = pin->GetOrAddInteger("monopole_gr", "npoints", 100);
@@ -100,7 +115,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Matter_t matter_cells("monopole_gr matter grid. cell centered.", NMAT, npoints);
   Volumes_t integration_volumes("monopole_gr matter integration volumes", npoints);
   Hypersurface_t hypersurface("monopole_gr hypersurface grid", NHYPER, npoints);
+
+  // Keep two copies of alpha around... one from this cycle and one
+  // from the last. They'll be swapped every cycle.
   Alpha_t alpha("monopole_gr lapse grid", npoints);
+  Alpha_t alpha_last("monopole_gr lapse grid", npoints);
 
   parthenon::par_for(
       parthenon::loop_pattern_flatrange_tag, "monopole_gr initialize grids",
@@ -113,6 +132,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
         hypersurface(Hypersurface::K, i) = 0;
         integration_volumes(i) = 0;
         alpha(i) = 1;
+        alpha_last(i) = 1;
       });
 
   // Host mirrors
@@ -148,6 +168,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("hypersurface_h", hypersurface_h);
   params.Add("lapse", alpha);
   params.Add("lapse_h", alpha_h);
+  params.Add("lapse_last", alpha_last);
   // mutable because the reducer is stateful
   params.Add("matter_reducer", matter_reducer, true);
   params.Add("volumes_reducer", volumes_reducer, true);
@@ -164,7 +185,47 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Radius radius(rin, rout, npoints);
   params.Add("radius", radius);
 
+  monopole_gr->EstimateTimestepBlock = EstimateTimestepBlock;
+
   return monopole_gr;
+}
+
+Real EstimateTimeStep(StateDescriptor *pkg) {
+  PARTHENON_REQUIRE_THROWS(pkg->label() == "monopole_gr",
+                           "Requires the monopole_gr package");
+  auto &params = pkg->AllParams();
+  const auto force_static = params.Get<bool>("force_static");
+  if (force_static) {
+    return std::numeric_limits<Real>::max();
+  }
+
+  const auto dtfac = params.Get<Real>("dtfac");
+  const auto npoints = params.Get<int>("npoints");
+  auto alpha = params.Get<Alpha_t>("lapse");
+  auto gradients = params.Get<Gradients_t>("gradients");
+
+  Real min_dt;
+  parthenon::par_reduce(
+      parthenon::loop_pattern_flatrange_tag, "monopole_gr time step",
+      parthenon::DevExecSpace(), 0, npoints - 1,
+      KOKKOS_LAMBDA(const int i, Real &lmin_dt) {
+        Real alpha_tscale = std::abs(robust::ratio(alpha, gradients(Gradients::DALPHADT, i)));
+        lmin_dt = std::min(ldt, alpha_tscale);
+      },
+      Kokkos::Min<Real>(min_dt));
+  return dtfac * min_dt;  
+}
+
+// Could template this but whatever. I'd only save like 4 lines.
+TaskStatus EstimateTimestepBlock(MeshBlockData<Real> *rc) {
+  auto pmb = rc->GetParentPointer();
+  StateDescriptor *pkg = pmb->packages.Get("monopole_gr").get();
+  return EstimateTimeStep(pkg);
+}
+TaskStatus EstimateTimeStepMesh(MeshData<Real> *rc) {
+  auto pmesh = rc->GetParentPointer();
+  StateDescriptor *pkg = pmb->packages.Get("monopole_gr").get();
+  return EstimateTimeStep(pkg);
 }
 
 TaskStatus MatterToHost(StateDescriptor *pkg, bool do_vols) {
@@ -353,6 +414,11 @@ TaskStatus SpacetimeToDevice(StateDescriptor *pkg) {
   Kokkos::deep_copy(hypersurface, hypersurface_h);
 
   auto alpha = params.Get<Alpha_t>("lapse");
+
+  // Copy old data from alpha into alpha_last
+  auto alpha_last = params.Get<Alpha_t>("lapse_last");
+  std::swap(alpha, alpha_last);
+
   auto alpha_h = params.Get<Alpha_host_t>("lapse_h");
   Kokkos::deep_copy(alpha, alpha_h);
 
@@ -374,15 +440,16 @@ TaskStatus SpacetimeToDevice(StateDescriptor *pkg) {
           hypersurface(Hypersurface::K, i) = 0;
         }
 
+        auto mask = !(force_static);
         Real r = radius.x(i);
         Real a = hypersurface(Hypersurface::A, i);
-        Real K = force_static ? 0 : hypersurface(Hypersurface::K, i);
+        Real K = mask*hypersurface(Hypersurface::K, i);
         Real rho = matter(Matter::RHO, i);
         Real j = matter(Matter::J_R, i);
         Real S = matter(Matter::trcS, i);
         Real Srr = matter(Matter::Srr, i);
         Real dadr = ShootingMethod::GetARHS(a, K, r, rho);
-        Real dKdr = force_static ? 0 : ShootingMethod::GetKRHS(a, K, r, j);
+        Real dKdr = mask*ShootingMethod::GetKRHS(a, K, r, j);
 
         Real a2 = a * a;
         Real a3 = a2 * a;
@@ -399,10 +466,9 @@ TaskStatus SpacetimeToDevice(StateDescriptor *pkg) {
           d2alphadr2 = (alpha(i - 1) + alpha(i + 1) - 2 * alpha(i)) / dr2;
         }
 
-        beta(i) = force_static ? 0 : -0.5 * alpha(i) * r * K;
+        beta(i) = mask*( -0.5 * alpha(i) * r * K);
         Real dbetadr =
-            force_static ? 0
-                         : -0.5 * (r * K * dalphadr + alpha(i) * K + alpha(i) * r * dKdr);
+          mask*( -0.5 * (r * K * dalphadr + alpha(i) * K + alpha(i) * r * dKdr));
         Real beta2 = beta(i) * beta(i);
         Real beta3 = beta(i) * beta2;
 
@@ -424,12 +490,40 @@ TaskStatus SpacetimeToDevice(StateDescriptor *pkg) {
         Real dbetadt = -0.5 * r * (alpha(i) * dKdt + K * dalphadt);
 
         // printf("%d: %.15e %.15e %.15e %.15e\n", i, dadt, dalphadt, dKdt, dbetadt);
-        gradients(Gradients::DADT, i) = force_static ? 0 : dadt;
-        gradients(Gradients::DALPHADT, i) = force_static ? 0 : dalphadt;
-        gradients(Gradients::DKDT, i) = force_static ? 0 : dKdt;
-        gradients(Gradients::DBETADT, i) = force_static ? 0 : dbetadt;
+        gradients(Gradients::DADT, i) = mask*dadt;
+        gradients(Gradients::DALPHADT, i) = mask*dalphadt;
+        gradients(Gradients::DKDT, i) = mask*dKdt;
+        gradients(Gradients::DBETADT, i) = mask*dbetadt;
       });
 
+  return TaskStatus::complete;
+}
+
+TaskStatus CheckRateOfChange(StateDescriptor *pkg, Real dt) {
+  auto dtwarn = params.Get<bool>("dtwarn");
+  if (dtwarn && parthenon::Globals::my_rank == 0) {
+    auto alpha = params.Get<Alpha_t>("lapse");
+    auto alpha_last = params.Get<Alpha_t>("lapse_last");
+    auto npoints = params.Get<int>("npoints");
+    auto gradients = params.Get<Gradients_t>("gradients");
+    auto dtwarn_eps = params.Get<Real>("dtwarn_eps");
+
+    Real err;
+    parthenon::par_reduce(
+      parthenon::loop_pattern_flatrange_tag, "monopole_gr check evolution time scales",
+      parthenon::DevExecSpace(), 0, npoints - 1,
+      KOKKOS_LAMBDA(const int i, Real &lmax_err) {
+        Real diff_alpha = (alpha(i) - alpha_last(i))/dt;
+        Real diff_dalpha = std::abs(diff_alpha - gradients(Gradients::DALPHADT, i));
+        lmax_err = std::max(lmax_err, diff_dalpha);
+      },
+      Kokkos::max<Real>(err));
+    if (err > dtwarn_eps) {
+      stc::cerr << "\tWarning! (alpha^i+1 - alpha^i)/dt is very different from dalpha/dt.\n"
+                << "\t\tTolerance set to " << dtwarn_eps
+                << std::endl;
+    }
+  }
   return TaskStatus::complete;
 }
 

--- a/src/monopole_gr/monopole_gr.cpp
+++ b/src/monopole_gr/monopole_gr.cpp
@@ -211,7 +211,7 @@ Real EstimateTimeStep(StateDescriptor *pkg) {
       KOKKOS_LAMBDA(const int i, Real &lmin_dt) {
         Real alpha_tscale =
             std::abs(robust::ratio(alpha, gradients(Gradients::DALPHADT, i)));
-        lmin_dt = std::min(ldt, alpha_tscale);
+        lmin_dt = std::min(lmin_dt, alpha_tscale);
       },
       Kokkos::Min<Real>(min_dt));
   return dtfac * min_dt;

--- a/src/monopole_gr/monopole_gr.hpp
+++ b/src/monopole_gr/monopole_gr.hpp
@@ -78,6 +78,25 @@
   beta^r = -(1/2) alpha r K^r_r
 
 
+  USING DENSITIZED CONSERVED VARS
+  --------------------------------
+
+  If we define:
+
+    rhob = sqrt(gamma) (tau + D)
+    Srb  = sqrt(gamma) S_r
+
+  then we can rewrite the eqns for a and K as
+
+  da/dr = a (4 - 4 a^2 + 3 a^2 (r K^r_r)^2 + 32 pi rhob)/(8 r)
+
+  d K^r_r = (8 pi Srb/a - 3 r K^r_r)/(r^2)
+
+  and the equation for alpha as
+
+  a^2 r alpha ((3/2) (K^r_r)^2 + 4 pi ((rho/(a r^2) + S)) +
+  ((1/a)(da/dr)r-2)dalpha/dr
+
   BOUNDARY CONDITIONS
   -------------------
   at r = 0:
@@ -145,7 +164,14 @@
 
   sqrt(g) rho    = tau + D
   sqrt(g) j^i    = S^i
-  Trc(S) = (rho_0 h + b^2)W^2 + 3(P + b^2/2) - b^i b_i
+  Trc(S) = (tau + D) + 3 P + b^2 - (rho + u) - (P b)^i (P b)_i
+  S^r_r  = tau + D + P - (rho + u) - (P b)^i (P b)_i
+
+  where
+
+  (P b)^i = P^i_mu b^mu
+
+  is the projection of the magnetic four-vector onto the hypersurface.
 
   In case of no B fields,
 

--- a/src/monopole_gr/monopole_gr_interface.hpp
+++ b/src/monopole_gr/monopole_gr_interface.hpp
@@ -27,10 +27,14 @@ using namespace parthenon::package::prelude;
 
 namespace MonopoleGR {
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
+Real EstimateTimeStep(StateDescriptor *pkg);
+Real EstimateTimestepBlock(MeshBlockData<Real> *rc);
+Real EstimateTimestepMesh(MeshBlockData<Real> *rc);
 TaskStatus MatterToHost(StateDescriptor *pkg, bool do_vols);
 TaskStatus IntegrateHypersurface(StateDescriptor *pkg);
 TaskStatus LinearSolveForAlpha(StateDescriptor *pkg);
 TaskStatus SpacetimeToDevice(StateDescriptor *pkg);
+TaskStatus CheckRateOfChange(StateDescriptor *pkg, Real dt);
 void DumpToTxt(const std::string &filename, StateDescriptor *pkg);
 inline void DumpCurrentState(StateDescriptor *pkg) { DumpToTxt("metric-last.dat", pkg); }
 TaskStatus DivideVols(StateDescriptor *pkg);

--- a/src/monopole_gr/monopole_gr_utils.hpp
+++ b/src/monopole_gr/monopole_gr_utils.hpp
@@ -31,7 +31,6 @@ namespace ShootingMethod {
 KOKKOS_INLINE_FUNCTION
 Real GetARHS(const Real a, const Real K, const Real r, const Real rho) {
   bool mask = (r > 0);
-  // return mask*robust::ratio(a*(4 - 4*a*a + 3*r*r*a*a*K*K + 32*M_PI*a*rho),8*r);
   return mask *
          robust::ratio(a * (4 + a * a * (-4 + r * r * (3 * K * K + 32 * M_PI * rho))),
                        8 * r);
@@ -41,9 +40,6 @@ KOKKOS_INLINE_FUNCTION
 Real GetKRHS(Real a, Real K, Real r, Real j) {
   bool mask = (r > 0);
   return mask * (8 * M_PI * a * a * j - robust::ratio(3. * K, r));
-  // return (r <= 0) ? 0 : 8 * M_PI * j - robust::ratio(3.*K, r);
-  // if (r <= 0) return 0;
-  // return robust::ratio(robust::ratio(8*M_PI*j, a) - 3*r*K,r*r);
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/monopole_gr/monopole_gr_utils.hpp
+++ b/src/monopole_gr/monopole_gr_utils.hpp
@@ -30,14 +30,17 @@ namespace ShootingMethod {
 
 KOKKOS_INLINE_FUNCTION
 Real GetARHS(const Real a, const Real K, const Real r, const Real rho) {
-  if (r <= 0) return 0;
-  // return robust::ratio(a*(4 - 4*a*a + 3*r*r*a*a*K*K + 32*M_PI*a*rho),8*r);
-  return a * (4 + a * a * (-4 + r * r * (3 * K * K + 32 * M_PI * rho))) / (8 * r);
+  bool mask = (r > 0);
+  // return mask*robust::ratio(a*(4 - 4*a*a + 3*r*r*a*a*K*K + 32*M_PI*a*rho),8*r);
+  return mask *
+         robust::ratio(a * (4 + a * a * (-4 + r * r * (3 * K * K + 32 * M_PI * rho))),
+                       8 * r);
 }
 
 KOKKOS_INLINE_FUNCTION
 Real GetKRHS(Real a, Real K, Real r, Real j) {
-  return (r <= 0) ? 0 : 8 * M_PI * a * a * j - robust::ratio(3. * K, r);
+  bool mask = (r > 0);
+  return mask * (8 * M_PI * a * a * j - robust::ratio(3. * K, r));
   // return (r <= 0) ? 0 : 8 * M_PI * j - robust::ratio(3.*K, r);
   // if (r <= 0) return 0;
   // return robust::ratio(robust::ratio(8*M_PI*j, a) - 3*r*K,r*r);

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -307,7 +307,7 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
                                 monopole.get())
                    : none);
       auto check_monopole_dt =
-          (ib == 0 ? tl.AddTask(spacetime_to_device, Monopole::CheckRateOfChange,
+          (ib == 0 ? tl.AddTask(spacetime_to_device, MonopoleGR::CheckRateOfChange,
                                 monopole.get(), tm.dt / 2)
                    : none);
     }

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -306,6 +306,10 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
           (ib == 0 ? tl.AddTask(lin_solve_for_lapse, MonopoleGR::SpacetimeToDevice,
                                 monopole.get())
                    : none);
+      auto check_monopole_dt =
+          (ib == 0 ? tl.AddTask(spacetime_to_device, Monopole::CheckRateOfChange,
+                                monopole.get(), tm.dt / 2)
+                   : none);
     }
 
     // update ghost cells


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As we discussed, we currently use lagged variables (i.e., from one subcycle behind) to source the monopole solver. We decided that a totally un-lagged procedure is, at the moment, not desirable. These changes are intended to lend a bit more confidence to our current approach.

I add two features that should add confidence:
1. I add a time step control that demands the time step be shorter than `dtfac * alpha/(dalpha/dt)`, which provides an approximate characteristic time scale for metric evolution. There's no stability criterion here... But presumably if we are taking time steps larger than the metric evolution time scale, then lagging our variables is certainly wrong.
2. I add a new task to the task list for the monopole solver that tries to estimate how good first-order operator splitting is. It compares a finite differences (dalpha/dt) to the analytic one computed by the solver and checks that these two rates are relatively close. It optionally spits out a warning if they are not.

Interested to hear what people think.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
