### PR TITLE
fix B-field normalization in torus pgen

### DIFF
--- a/src/fluid/tmunu.hpp
+++ b/src/fluid/tmunu.hpp
@@ -122,7 +122,7 @@ class StressEnergyTensorCon {
       b[l] = iW * (b_(l, std::forward<Args>(args)...) + alpha * b[0] * u[l]);
     }
 
-    bsq = (Bsq + alpha * alpha * b[0] * b[0]) * iW * iW;
+    bsq = Bsq * iW * iW + Bdotv * Bdotv;
   }
 
   Pack pack_;

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -247,7 +247,14 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real rho_av =
             0.25 * (v(irho, kb.s, j, i) + v(irho, kb.s, j, i - 1) +
                     v(irho, kb.s, j - 1, i) + v(irho, kb.s, j - 1, i - 1));
-        const Real q = rho_av / rho_rmax - 0.2;
+        // JMM: Classic HARM divides by rho_max here, to normalize rho_av.
+        // However, we have already normalized rho, and thus rho_av. So
+        // we should not renormalize.
+        // This will change in the case of realistic EOS, when we
+        // can't simply renormalize by density and must instead do
+        // something clever with units.
+        // const Real q = rho_av / rho_rmax - 0.2;
+        const Real q = rho_av - 0.2;
         A(j, i) = (q > 0 ? q : 0.0);
       });
 
@@ -256,17 +263,19 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
     pmb->par_for(
         "Phoebus::ProblemGenerator::Torus3", kb.s, kb.e, jb.s, jb.e - 1, ib.s, ib.e - 1,
         KOKKOS_LAMBDA(const int k, const int j, const int i) {
-          const Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
+          // JMM: HARM/bhlight divides by gdet, not gamdet.
+          // This means the HARM primitives are smaller than the Phoebus primitives by
+          // a factor of alpha.
+          const Real gamdet = geom.DetGamma(CellLocation::Cent, k, j, i);
           v(iblo, k, j, i) = -(A(j, i) - A(j + 1, i) + A(j, i + 1) - A(j + 1, i + 1)) /
-                             (2.0 * coords.Dx(X2DIR, k, j, i) * gdet);
+                             (2.0 * coords.Dx(X2DIR, k, j, i) * gamdet);
           v(iblo + 1, k, j, i) = (A(j, i) + A(j + 1, i) - A(j, i + 1) - A(j + 1, i + 1)) /
-                                 (2.0 * coords.Dx(X1DIR, k, j, i) * gdet);
+                                 (2.0 * coords.Dx(X1DIR, k, j, i) * gamdet);
           v(ibhi, k, j, i) = 0.0;
         });
   }
 
   fluid::PrimitiveToConserved(rc);
-  printf("Problem initialized!\n");
 }
 
 void ProblemModifier(ParameterInput *pin) {
@@ -330,7 +339,6 @@ void PostInitializationModifier(ParameterInput *pin, Mesh *pmesh) {
         ib.e,
         KOKKOS_LAMBDA(const int k, const int j, const int i, Real &beta_min) {
           // compute bsq for max
-          Real vsq = 0.0;
           Real Bsq = 0.0;
           Real Bdotv = 0.0;
           Real gcov[3][3];
@@ -338,12 +346,10 @@ void PostInitializationModifier(ParameterInput *pin, Mesh *pmesh) {
           Real vp[3] = {v(ivlo, k, j, i), v(ivlo + 1, k, j, i), v(ivlo + 2, k, j, i)};
           const Real W = phoebus::GetLorentzFactor(vp, gcov);
           SPACELOOP2(m, n) {
-            vsq += gcov[m][n] * v(ivlo + m, k, j, i) / W * v(ivlo + n, k, j, i) / W;
             Bdotv += gcov[m][n] * v(ivlo + m, k, j, i) / W * v(iblo + n, k, j, i);
             Bsq += gcov[m][n] * v(iblo + m, k, j, i) * v(iblo + n, k, j, i);
           }
-          const Real b0 = W * Bdotv;
-          const Real bsq = (Bsq + b0 * b0) / (W * W);
+          const Real bsq = Bsq / (W * W) + Bdotv * Bdotv;
           const Real beta = robust::ratio(v(iprs, k, j, i), 0.5 * bsq);
           if (v(irho, k, j, i) > rho_min_bnorm && beta < beta_min) beta_min = beta;
         },


### PR DESCRIPTION
…Bsq calc in tmunu and torus

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

What it says on the can. The issue is that the density is already normalized when the vector potential is computed. Dividing by an additional factor of `rho_rmax` shrinks `A` and, thanks to the `-0.2` in the definition, kills `A`, and thus `B`, at the edges of the torus.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
