### PR TITLE
reduce geometry memory footprint

### DIFF
--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -115,9 +115,9 @@ class Cached {
     }
     // These variables only exist at cell centers
     PARTHENON_DEBUG_REQUIRE(imap["g.c.dalpha"].second >= 0, "variable exists");
-    PARTHENON_DEBUG_REQUIRE(
-        imap["g.c.dalpha"].second - imap["g.c.dalpha"].first + 1 == nvar_deriv_,
-        "variable shape correct");
+    PARTHENON_DEBUG_REQUIRE(imap["g.c.dalpha"].second - imap["g.c.dalpha"].first + 1 ==
+                                nvar_deriv_,
+                            "variable shape correct");
     idx_[CellLocation::Cent].dalpha = imap["g.c.dalpha"].first;
     PARTHENON_DEBUG_REQUIRE(imap["g.c.dg"].second >= 0, "variable exists");
     idx_[CellLocation::Cent].dg = imap["g.c.dg"].first;

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -396,6 +396,11 @@ void InitializeCachedCoordinateSystem(ParameterInput *pin, StateDescriptor *geom
   bool axisymmetric = pin->GetOrAddBoolean("geometry", "axisymmetric", false);
   params.Add("axisymmetric", axisymmetric);
 
+  // This tells the goemetry infrastructure not to call
+  // SetGeometryDefault, because the cached geometry will handle it.
+  bool do_defaults = false;
+  params.Add("do_defaults", do_defaults);
+
   // Request fields for cache
   Utils::MeshBlockShape dims(pin);
 
@@ -469,7 +474,6 @@ CachedOverMesh<System> GetCachedCoordinateSystem(MeshData<Real> *rc) {
   return CachedOverMesh<System>(rc, system, axisymmetric, time_dependent);
 }
 
-// We rely on SetGeometryDefault for coords
 template <typename System, typename Data>
 void SetCachedCoordinateSystem(Data *rc) {
   auto pparent = rc->GetParentPointer();
@@ -595,6 +599,9 @@ void SetCachedCoordinateSystem(Data *rc) {
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
         lamb(b, k, j, i, CellLocation::Face3);
       });
+
+  // Call SetGeometryDefault to set the coords objects.
+  impl::SetGeometryDefault(rc, system);
 }
 
 } // namespace Geometry

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -147,7 +147,8 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void ContravariantShift(CellLocation loc, int b, int k, int j, int i,
                           Real beta[NDSPACE]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     SPACELOOP(d) { beta[d] = pack_(b, idx_[loc].bcon + d, k, j, i); }
   }
@@ -163,7 +164,8 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void Metric(CellLocation loc, int b, int k, int j, int i,
               Real gamma[NDSPACE][NDSPACE]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     SPACELOOP2(m, n) {     // gamma_{ij} = g_{ij}
       int offst = Utils::Flatten2(m + 1, n + 1, NDFULL);
@@ -182,7 +184,8 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void MetricInverse(CellLocation loc, int b, int k, int j, int i,
                      Real gamma[NDSPACE][NDSPACE]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     SPACELOOP2(m, n) {
       int offst = Utils::Flatten2(m, n, NDSPACE);
@@ -201,7 +204,8 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void SpacetimeMetric(CellLocation loc, int b, int k, int j, int i,
                        Real g[NDFULL][NDFULL]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     SPACETIMELOOP2(mu, nu) {
       int offst = Utils::Flatten2(mu, nu, NDFULL);
@@ -222,7 +226,8 @@ class Cached {
   void SpacetimeMetricInverse(CellLocation loc, int b, int k, int j, int i,
                               Real g[NDFULL][NDFULL]) const {
     using robust::ratio;
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     auto &idx = idx_[loc];
     Real alpha2 = Lapse(loc, b, k, j, i);
@@ -248,7 +253,8 @@ class Cached {
   }
   KOKKOS_INLINE_FUNCTION
   Real DetGamma(CellLocation loc, int b, int k, int j, int i) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     return pack_(b, idx_[loc].detgam, k, j, i);
   }
@@ -268,14 +274,16 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void ConnectionCoefficient(CellLocation loc, int k, int j, int i,
                              Real Gamma[NDFULL][NDFULL][NDFULL]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     Utils::SetConnectionCoeffByFD(*this, Gamma, loc, k, j, i);
   }
   KOKKOS_INLINE_FUNCTION
   void ConnectionCoefficient(CellLocation loc, int bid, int k, int j, int i,
                              Real Gamma[NDFULL][NDFULL][NDFULL]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     Utils::SetConnectionCoeffByFD(*this, Gamma, loc, bid, k, j, i);
   }
@@ -287,7 +295,8 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void MetricDerivative(CellLocation loc, int b, int k, int j, int i,
                         Real dg[NDFULL][NDFULL][NDFULL]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     const int offset = !time_dependent_;
     SPACETIMELOOP2(mu, nu) {
@@ -310,7 +319,8 @@ class Cached {
   }
   KOKKOS_INLINE_FUNCTION
   void GradLnAlpha(CellLocation loc, int b, int k, int j, int i, Real da[NDFULL]) const {
-    PARTHENON_DEBUG_REQUIRE(CellLocation != Corn, "Node-centered values not available.");
+    PARTHENON_DEBUG_REQUIRE(loc != CellLocation::Corn,
+                            "Node-centered values not available.");
     k *= (!axisymmetric_); // maps k -> 0 for axisymmetric spacetimes. Otherwise no-op
     const int offset = !time_dependent_;
     da[0] = 0; // gets overwritten if time-dependent metric
@@ -490,6 +500,8 @@ void SetCachedCoordinateSystem(Data *rc) {
   }
   PARTHENON_DEBUG_REQUIRE(imap["g.c.dalpha"].second >= 0, "Variable exists");
   PARTHENON_DEBUG_REQUIRE(imap["g.c.dg"].second >= 0, "Variable exists");
+  idx[CellLocation::Cent].dg = imap["g.c.dg"].first;
+  idx[CellLocation::Cent].dalpha = imap["g.c.dalpha"].first;
 
   auto lamb = KOKKOS_LAMBDA(const int b, const int k, const int j, const int i,
                             const CellLocation loc) {

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -116,11 +116,11 @@ class Cached {
     // These variables only exist at cell centers
     PARTHENON_DEBUG_REQUIRE(imap["g.c.dalpha"].second >= 0, "variable exists");
     PARTHENON_DEBUG_REQUIRE(
-        imap["g.c.dalpha"].second - imap["g." + loc + ".dalpha"].first + 1 == nvar_deriv_,
+        imap["g.c.dalpha"].second - imap["g.c.dalpha"].first + 1 == nvar_deriv_,
         "variable shape correct");
-    idx_[CellLocation::Cent].dalpha = imap["g." + loc + ".dalpha"].first;
+    idx_[CellLocation::Cent].dalpha = imap["g.c.dalpha"].first;
     PARTHENON_DEBUG_REQUIRE(imap["g.c.dg"].second >= 0, "variable exists");
-    idx_[CellLocation::Cent].dg = imap["g." + loc + ".dg"].first;
+    idx_[CellLocation::Cent].dg = imap["g.c.dg"].first;
     icoord_c_ = imap["g.c.coord"].first;
     // This variable only exists at cell corners
     icoord_n_ = imap["g.n.coord"].first;
@@ -405,7 +405,7 @@ void InitializeCachedCoordinateSystem(ParameterInput *pin, StateDescriptor *geom
   std::vector<std::string> cent_only_names = {"dalpha", "dg"};
   PARTHENON_REQUIRE_THROWS(var_sizes.size() == var_names.size(),
                            "Same number of variables as sizes");
-  PARTHENON_REQUIRE_THROWS(cent_only_sizes.size() == cent_names.size(),
+  PARTHENON_REQUIRE_THROWS(cent_only_sizes.size() == cent_only_names.size(),
                            "Same number of variables as sizes");
   // Cell variables
   for (int i = 0; i < var_sizes.size(); ++i) {
@@ -419,16 +419,16 @@ void InitializeCachedCoordinateSystem(ParameterInput *pin, StateDescriptor *geom
     geometry->AddField("g.c." + var_names[i], m);
   }
   // Do metric derivative and lapse derivative separately, as
-  // they're only available on nodes
-  for (int i = 0; i < node_only_sizes.size(); ++i) {
+  // they're only available on cell centers
+  for (int i = 0; i < cent_only_sizes.size(); ++i) {
     if (axisymmetric) {
-      shape = {dims.nx1, dims.nx2, 1, node_only_sizes[i]};
+      shape = {dims.nx1, dims.nx2, 1, cent_only_sizes[i]};
       m = Metadata(flags_o, shape);
     } else {
-      shape = {node_only_sizes[i]};
+      shape = {cent_only_sizes[i]};
       m = Metadata(flags_c, shape);
     }
-    geometry->AddField("g.c." + node_only_names[i], m);
+    geometry->AddField("g.c." + cent_only_names[i], m);
   }
   // face variables
   for (int d = 1; d <= 3; ++d) {

--- a/src/geometry/modified_system.hpp
+++ b/src/geometry/modified_system.hpp
@@ -196,8 +196,7 @@ class Modified {
     Real Jcov[NDSPACE][NDSPACE];
     Real Jcon[NDSPACE][NDSPACE];
     GetTransformation_(X1, X2, X3, Cnew, Jcov, Jcon);
-    C[0] = X0;
-    SPACELOOP(i) C[i] = Cnew[i];
+    s_.Coords(X0, Cnew[0], Cnew[1], Cnew[2], C);
   }
 
  private:


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is based on a discussion with @jdolence about what geometry objects we actually need to access and from where. The geometry cache, especially the metric derivatives, take up a lot of memory. I am currently storing all geometry objects at all cell centers, faces, and nodes. However, we only really need metric derivatives at cell centers (for source terms) and the nodes are totally untouched.

This PR removes node-centered variables entirely, except for "physical coordinate locations," which is useful for 3D visualization tools like visit. It also removes metric derivatives from cell faces. This reduces the memory footprint of the caching machinery substantially... by a bit more than a factor of 2.

The price, of course, is that metric derivatives---which are needed to compute the christoffel symbols---are no longer available at faces and nodes. I don't believe we need them there, but I could be wrong. In particular, @brryan do we need the christoffel symbols in the ghost zones? If so, face- or node-centered data is probably useful for interpolation. If not, though, we can probably get away with these savings.

Another price is to be paid in the API for the geometry. I now have the code die (in debug mode) if you try to access node-centered data where it is not available. Is this an acceptable price?

I'm interested in folk's thoughts. If people like this, then we should run a torus, and the snake linear modes test, with caching on to make sure I didn't break anything.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
