### PR TITLE
 Add the ability to compute metric derivatives by finite differences on the grid

### DIFF
--- a/inputs/linear_modes.pin
+++ b/inputs/linear_modes.pin
@@ -63,10 +63,10 @@ num_threads = 1         # maximum number of OMP threads
 <phoebus/mesh>
 #bc_vars = primitive
 
-<parthenon/meshblock>
-nx1 = 128
-nx2 = 128
-nx3 = 1
+# <parthenon/meshblock>
+# nx1 = 128
+# nx2 = 128
+# nx3 = 1
 
 <parthenon/refinement0>
 field = c.c.bulk.rho
@@ -91,6 +91,7 @@ vy = 0. # 0.524631
 # vy = 0.81     # shift. Default is 0.
 # vy = 0.617213 # shift. Default is 0.
 # vy = 0      # shift. Default is 0.
+do_fd_on_grid = false
 
 <eos>
 type = IdealGas

--- a/inputs/spherical_shock_tube.pin
+++ b/inputs/spherical_shock_tube.pin
@@ -92,10 +92,10 @@ ox3_bc      = periodic      # Outer-X3 boundary condition flfgag
 
 num_threads = 1         # maximum number of OMP threads
 
-<parthenon/meshblock>
-nx1 = 512
-nx2 = 1
-nx3 = 1
+# <parthenon/meshblock>
+# nx1 = 512
+# nx2 = 1
+# nx3 = 1
 
 <parthenon/refinement0>
 field = c.c.bulk.rho
@@ -104,6 +104,7 @@ max_level = 3
 
 <geometry>
 axisymmetry = false
+do_fd_on_grid = false
 
 <eos>
 type = IdealGas

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -102,6 +102,8 @@ mhd = true
 
 <geometry>
 a = 0.9375
+axisymmetric = true
+do_fd_on_grid = false
 
 <coordinates>
 derefine_poles = false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(phoebus
   pgen/advection.cpp
   pgen/blandford_mckee.cpp
   pgen/bondi.cpp
+  pgen/check_cached_geom.cpp
   pgen/friedmann.cpp
   pgen/homogeneous_sphere.cpp
   pgen/kh.cpp

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -14,14 +14,17 @@
 #ifndef GEOMETRY_CACHED_SYSTEM_HPP_
 #define GEOMETRY_CACHED_SYSTEM_HPP_
 
+// C++ includes
 #include <array>
 #include <cmath>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
 
 // Parthenon includes
 #include <coordinates/coordinates.hpp>
+#include <globals.hpp>
 #include <kokkos_abstraction.hpp>
 #include <parthenon/package.hpp>
 #include <utils/error_checking.hpp>
@@ -401,6 +404,26 @@ void InitializeCachedCoordinateSystem(ParameterInput *pin, StateDescriptor *geom
   bool do_defaults = false;
   params.Add("do_defaults", do_defaults);
 
+  // Optionally use finite differences on the grid to set the metric
+  // derivatives. If the geometry we're caching specifies one way or
+  // the other, we defer to the geometry we're caching, and
+  // warn. Otherwise, we defer to the input deck.
+  bool do_fd_on_grid;
+  bool do_fd_on_grid_pin = pin->GetOrAddBoolean("geometry", "do_fd_on_grid", false);
+  if (params.hasKey("do_fd_on_grid")) {
+    do_fd_on_grid = params.Get<bool>("do_fd_on_grid");
+    if (parthenon::Globals::my_rank == 0) {
+      std::stringstream ss;
+      ss << "do_fd_on_grid set by input deck as " << do_fd_on_grid_pin
+         << " but set by the geometry class to be " << do_fd_on_grid
+         << ". The geometry class takes priority." << std::endl;
+      PARTHENON_WARN(ss);
+    }
+  } else {
+    do_fd_on_grid = do_fd_on_grid_pin;
+    params.Add("do_fd_on_grid", do_fd_on_grid);
+  }
+
   // Request fields for cache
   Utils::MeshBlockShape dims(pin);
 
@@ -483,6 +506,7 @@ void SetCachedCoordinateSystem(Data *rc) {
   parthenon::Params &params = pkg->AllParams();
   bool axisymmetric = params.Get<bool>("axisymmetric");
   bool time_dependent = params.Get<bool>("time_dependent");
+  bool do_fd_on_grid = params.Get<bool>("do_fd_on_grid");
   const int nvar_deriv = time_dependent ? NDFULL : NDSPACE;
 
   Impl::LocArray<Impl::GeomPackIndices> idx;
@@ -562,6 +586,45 @@ void SetCachedCoordinateSystem(Data *rc) {
       }
     }
   };
+  // Compute derivatives by finite differences
+  // If time-derivatives present, use this to overwrite non time-derivative calls
+  // If time-derivatives not present, just do this.
+  // Strategy is to do second-order finite differences by diffing cell
+  // faces to compute cell centered values.
+  auto lamb_derivs_fd =
+      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+    const auto loc = CellLocation::Cent;
+    const auto &coords = pack.GetCoords(b);
+    const Real alpha = system.Lapse(loc, b, k, j, i);
+    Real alpha_fp, alpha_fm;
+    Real g_fp[NDFULL][NDFULL];
+    Real g_fm[NDFULL][NDFULL];
+    const CellLocation floc[] = {CellLocation::Face1, CellLocation::Face2,
+                                 CellLocation::Face3};
+    SPACELOOP(d) {
+      int idx_fp[] = {k, j, i};
+      idx_fp[NDSPACE - 1 - d] += 1;
+      alpha_fp = system.Lapse(floc[d], b, idx_fp[0], idx_fp[1], idx_fp[2]);
+      alpha_fm = system.Lapse(floc[d], b, k, j, i);
+      system.SpacetimeMetric(floc[d], b, idx_fp[0], idx_fp[1], idx_fp[2], g_fp);
+      system.SpacetimeMetric(floc[d], b, k, j, i, g_fm);
+      // Recall that we're setting GradLnAlpha, not GradAlpha;
+      const Real da = robust::ratio(alpha_fp - alpha_fm, alpha * coords.Dx(d + 1));
+      // if time_dependent, then we don't want to fill the d/dt, mu = 0 terms
+      pack(b, idx[loc].dalpha + d + time_dependent, k, j, i) = da;
+      // 2d loop for metric
+      const Real sigma = d + time_dependent;
+      for (int mu = 0; mu < NDFULL; ++mu) {
+        for (int nu = mu; nu < NDFULL; ++nu) {
+          // if time_dependent, then we don't want to fill the d/dt, sigma = 0 terms
+          const int flat =
+              idx[loc].dg + nvar_deriv * Utils::Flatten2(mu, nu, NDFULL) + sigma;
+          const Real dg = robust::ratio(g_fp[mu][nu] - g_fm[mu][nu], coords.Dx(d + 1));
+          pack(b, flat, k, j, i) = dg;
+        }
+      }
+    }
+  };
 
   IndexRange ib = rc->GetBoundsI(IndexDomain::entire);
   IndexRange jb = rc->GetBoundsJ(IndexDomain::entire);
@@ -574,12 +637,16 @@ void SetCachedCoordinateSystem(Data *rc) {
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
         lamb(b, k, j, i, CellLocation::Cent);
       });
-  parthenon::par_for(
-      DEFAULT_LOOP_PATTERN, "SetGeometry::Set Cached data, derivs", DevExecSpace(), 0,
-      pack.GetDim(5) - 1, kbs, kbe, jb.s, jb.e, ib.s, ib.e,
-      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-        lamb_derivs(b, k, j, i);
-      });
+  // Skip if do_fd_on_grid and not time_dependent, since these can be
+  // all set by FD.
+  if (time_dependent || !do_fd_on_grid) {
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "SetGeometry::Set Cached data, derivs", DevExecSpace(), 0,
+        pack.GetDim(5) - 1, kbs, kbe, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+          lamb_derivs(b, k, j, i);
+        });
+  }
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "SetGeometry::Set Cached data, Face1", DevExecSpace(), 0,
       pack.GetDim(5) - 1, kbs, kbe, jb.s, jb.e, ib.s, ib.e + 1,
@@ -599,7 +666,15 @@ void SetCachedCoordinateSystem(Data *rc) {
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
         lamb(b, k, j, i, CellLocation::Face3);
       });
-
+  if (do_fd_on_grid) {
+    kbe = axisymmetric ? 0 : kb.e;
+    parthenon::par_for(
+        DEFAULT_LOOP_PATTERN, "SetGeometry::Set Cached data, derivs via FD",
+        DevExecSpace(), 0, pack.GetDim(5) - 1, kbs, kbe, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+          lamb_derivs_fd(b, k, j, i);
+        });
+  }
   // Call SetGeometryDefault to set the coords objects.
   impl::SetGeometryDefault(rc, system);
 }

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -1,0 +1,84 @@
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <typeinfo>
+
+// Parthenon includes
+#include <kokkos_abstraction.hpp>
+#include <utils/error_checking.hpp>
+
+// Phoebus includes
+#include "geometry/coordinate_systems.hpp"
+#include "geometry/geometry.hpp"
+#include "pgen/pgen.hpp"
+#include "phoebus_utils/relativity_utils.hpp"
+#include "phoebus_utils/robust.hpp"
+
+// A test that the geometry machinery with finite differences is
+// working correctly.
+
+namespace check_cached_geom {
+
+KOKKOS_FORCEINLINE_FUNCTION
+Real RelErr(const Real a, const Real b) {
+  return 2 * robust::ratio(std::abs(a - b), a + b);
+}
+
+void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
+  using namespace Geometry;
+  using AnalyticGeometry_t = Analytic<PHOEBUS_GEOMETRY, IndexerMeshBlock>;
+  PARTHENON_REQUIRE(
+      typeid(CachedOverMeshBlock<AnalyticGeometry_t>) == typeid(CoordSysMeshBlock),
+      "This problem generator only supports analytic geometries cached over meshblocks");
+  auto &rc = pmb->meshblock_data.Get();
+  auto geom_cached = GetCoordinateSystem<CoordSysMeshBlock>(rc.get());
+  auto geom_analytic = GetCoordinateSystem<AnalyticGeometry_t>(rc.get());
+
+  IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
+  IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
+  IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+
+  Real max_err;
+  auto loc = CellLocation::Cent;
+  pmb->par_reduce(
+      "Phoebus::ProblemGenerator::CheckCachedGeometry", kb.s, kb.e, jb.s, jb.e, ib.s,
+      ib.e,
+      KOKKOS_LAMBDA(const int k, const int j, const int i, Real &le) {
+        Real da_an[NDFULL];
+        Real da_ca[NDFULL];
+        Real dg_an[NDFULL][NDFULL][NDFULL];
+        Real dg_ca[NDFULL][NDFULL][NDFULL];
+        geom_analytic.GradLnAlpha(loc, k, j, i, da_an);
+        geom_cached.GradLnAlpha(loc, k, j, i, da_ca);
+        geom_analytic.MetricDerivative(loc, k, j, i, dg_an);
+        geom_cached.MetricDerivative(loc, k, j, i, dg_ca);
+
+        SPACETIMELOOP(mu) {
+          Real diff = RelErr(da_an[mu], da_ca[mu]);
+          le = std::max(le, diff);
+        }
+        SPACETIMELOOP3(mu, nu, sigma) {
+          Real diff = RelErr(dg_an[mu][nu][sigma], dg_ca[mu][nu][sigma]);
+          le = std::max(le, diff);
+        }
+      },
+      Kokkos::Max<Real>(max_err));
+  printf("Maximum error = %.14e\n", max_err);
+  std::exit(1);
+}
+
+} // namespace check_cached_geom

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -1,4 +1,4 @@
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2022. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -32,6 +32,7 @@ using namespace parthenon::package::prelude;
 #define FOREACH_PROBLEM                                                                  \
   PROBLEM(phoebus)                                                                       \
   PROBLEM(advection)                                                                     \
+  PROBLEM(check_cached_geom)                                                             \
   PROBLEM(shock_tube)                                                                    \
   PROBLEM(friedmann)                                                                     \
   PROBLEM(linear_modes)                                                                  \


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

In my on-going quest to build the geometry machinery up to the ability to do on-grid computations for e.g., `MonopoleCart`, in this PR I introduce the ability to compute metric derivatives via finite differences on the grid when using cached geometry.

I allow a given geometry to specify whether or not it should do this when cached via the `geometry/do_fd_on_grid` `param`. If this `param` is not set, the cached geometry will read it in from the input deck.

The finite differences themselves are computed as centered differences where the cell-centered value is set by the differences across faces. This is vastly simplified by PR #101, which removed the metric derivatives at faces and nodes.

I add a new problem generator to be able to test this machinery, though it is not integrated into automated tests, `pgen/check_cached_geom.hpp` which reports the error between metric derivatives for a cached geometry and an analytic one. This has the added bonus of double checking that memory locations in the cache are set correctly.

There will be one follow-up PR for the geometry infrastructure after this one, where I modify the cached geometry to use interpolation when values between grid points are requested, rather than passing through to the underlying geometry object. That final change will be to support, e.g., particles. With that final change, I think it will be straightforward to set up a `MonopoleCart` geometry which does everything on the grid.

Pinging @jdolence @brryan @lroberts36 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
