### PR TITLE
Provide interpolation for Cached Geometry

### DIFF
--- a/inputs/spherical_shock_tube.pin
+++ b/inputs/spherical_shock_tube.pin
@@ -103,7 +103,7 @@ method = derivative_order_1
 max_level = 3
 
 <geometry>
-axisymmetry = false
+axisymmetric = false
 do_fd_on_grid = false
 
 <eos>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ add_executable(phoebus
   phoebus_utils/unit_conversions.cpp
   phoebus_utils/unit_conversions.hpp
   phoebus_utils/linear_algebra.hpp
+  phoebus_utils/phoebus_interpolation.hpp
   phoebus_utils/reduction.hpp
   phoebus_utils/relativity_utils.hpp
   phoebus_utils/robust.hpp

--- a/src/geometry/analytic_system.hpp
+++ b/src/geometry/analytic_system.hpp
@@ -169,6 +169,10 @@ class Analytic {
     return system_.Lapse(X0, X1, X2, X3);
   }
   KOKKOS_INLINE_FUNCTION
+  Real Lapse(int b, Real X0, Real X1, Real X2, Real X3) const {
+    return system_.Lapse(X0, X1, X2, X3);
+  }
+  KOKKOS_INLINE_FUNCTION
   Real Lapse(CellLocation loc, int k, int j, int i) const {
     Real X1, X2, X3;
     indexer_.GetX(loc, k, j, i, X1, X2, X3);
@@ -183,6 +187,10 @@ class Analytic {
 
   KOKKOS_INLINE_FUNCTION
   void ContravariantShift(Real X0, Real X1, Real X2, Real X3, Real beta[NDSPACE]) const {
+    return system_.ContravariantShift(X0, X1, X2, X3, beta);
+  }
+  KOKKOS_INLINE_FUNCTION
+  void ContravariantShift(int b, Real X0, Real X1, Real X2, Real X3, Real beta[NDSPACE]) const {
     return system_.ContravariantShift(X0, X1, X2, X3, beta);
   }
   KOKKOS_INLINE_FUNCTION
@@ -205,6 +213,10 @@ class Analytic {
     return system_.Metric(X0, X1, X2, X3, gamma);
   }
   KOKKOS_INLINE_FUNCTION
+  void Metric(int b, Real X0, Real X1, Real X2, Real X3, Real gamma[NDSPACE][NDSPACE]) const {
+    return system_.Metric(X0, X1, X2, X3, gamma);
+  }
+  KOKKOS_INLINE_FUNCTION
   void Metric(CellLocation loc, int k, int j, int i, Real gamma[NDSPACE][NDSPACE]) const {
     Real X1, X2, X3;
     indexer_.GetX(loc, k, j, i, X1, X2, X3);
@@ -220,6 +232,11 @@ class Analytic {
 
   KOKKOS_INLINE_FUNCTION
   void MetricInverse(Real X0, Real X1, Real X2, Real X3,
+                     Real gamma[NDSPACE][NDSPACE]) const {
+    return system_.MetricInverse(X0, X1, X2, X3, gamma);
+  }
+  KOKKOS_INLINE_FUNCTION
+  void MetricInverse(int b, Real X0, Real X1, Real X2, Real X3,
                      Real gamma[NDSPACE][NDSPACE]) const {
     return system_.MetricInverse(X0, X1, X2, X3, gamma);
   }
@@ -243,6 +260,10 @@ class Analytic {
     return system_.SpacetimeMetric(X0, X1, X2, X3, g);
   }
   KOKKOS_INLINE_FUNCTION
+  void SpacetimeMetric(int b, Real X0, Real X1, Real X2, Real X3, Real g[NDFULL][NDFULL]) const {
+    return system_.SpacetimeMetric(X0, X1, X2, X3, g);
+  }
+  KOKKOS_INLINE_FUNCTION
   void SpacetimeMetric(CellLocation loc, int k, int j, int i,
                        Real g[NDFULL][NDFULL]) const {
     Real X1, X2, X3;
@@ -259,6 +280,11 @@ class Analytic {
 
   KOKKOS_INLINE_FUNCTION
   void SpacetimeMetricInverse(Real X0, Real X1, Real X2, Real X3,
+                              Real g[NDFULL][NDFULL]) const {
+    return system_.SpacetimeMetricInverse(X0, X1, X2, X3, g);
+  }
+  KOKKOS_INLINE_FUNCTION
+  void SpacetimeMetricInverse(int b, Real X0, Real X1, Real X2, Real X3,
                               Real g[NDFULL][NDFULL]) const {
     return system_.SpacetimeMetricInverse(X0, X1, X2, X3, g);
   }
@@ -282,6 +308,10 @@ class Analytic {
     return system_.DetGamma(X0, X1, X2, X3);
   }
   KOKKOS_INLINE_FUNCTION
+  Real DetGamma(int b, Real X0, Real X1, Real X2, Real X3) const {
+    return system_.DetGamma(X0, X1, X2, X3);
+  }
+  KOKKOS_INLINE_FUNCTION
   Real DetGamma(CellLocation loc, int k, int j, int i) const {
     Real X1, X2, X3;
     indexer_.GetX(loc, k, j, i, X1, X2, X3);
@@ -299,6 +329,10 @@ class Analytic {
     return system_.DetG(X0, X1, X2, X3);
   }
   KOKKOS_INLINE_FUNCTION
+  Real DetG(int b, Real X0, Real X1, Real X2, Real X3) const {
+    return system_.DetG(X0, X1, X2, X3);
+  }
+  KOKKOS_INLINE_FUNCTION
   Real DetG(CellLocation loc, int k, int j, int i) const {
     Real X1, X2, X3;
     indexer_.GetX(loc, k, j, i, X1, X2, X3);
@@ -313,6 +347,11 @@ class Analytic {
 
   KOKKOS_INLINE_FUNCTION
   void ConnectionCoefficient(Real X0, Real X1, Real X2, Real X3,
+                             Real Gamma[NDFULL][NDFULL][NDFULL]) const {
+    return system_.ConnectionCoefficient(X0, X1, X2, X3, Gamma);
+  }
+  KOKKOS_INLINE_FUNCTION
+  void ConnectionCoefficient(int b, Real X0, Real X1, Real X2, Real X3,
                              Real Gamma[NDFULL][NDFULL][NDFULL]) const {
     return system_.ConnectionCoefficient(X0, X1, X2, X3, Gamma);
   }
@@ -336,6 +375,11 @@ class Analytic {
     return system_.MetricDerivative(X0, X1, X2, X3, dg);
   }
   KOKKOS_INLINE_FUNCTION
+  void MetricDerivative(int b, Real X0, Real X1, Real X2, Real X3,
+                        Real dg[NDFULL][NDFULL][NDFULL]) const {
+    return system_.MetricDerivative(X0, X1, X2, X3, dg);
+  }
+  KOKKOS_INLINE_FUNCTION
   void MetricDerivative(CellLocation loc, int k, int j, int i,
                         Real dg[NDFULL][NDFULL][NDFULL]) const {
     Real X1, X2, X3;
@@ -355,6 +399,10 @@ class Analytic {
     return system_.GradLnAlpha(X0, X1, X2, X3, da);
   }
   KOKKOS_INLINE_FUNCTION
+  void GradLnAlpha(int b, Real X0, Real X1, Real X2, Real X3, Real da[NDFULL]) const {
+    return system_.GradLnAlpha(X0, X1, X2, X3, da);
+  }
+  KOKKOS_INLINE_FUNCTION
   void GradLnAlpha(CellLocation loc, int k, int j, int i, Real da[NDFULL]) const {
     Real X1, X2, X3;
     indexer_.GetX(loc, k, j, i, X1, X2, X3);
@@ -369,6 +417,10 @@ class Analytic {
 
   KOKKOS_INLINE_FUNCTION
   void Coords(Real X0, Real X1, Real X2, Real X3, Real C[NDFULL]) const {
+    return system_.Coords(X0, X1, X2, X3, C);
+  }
+  KOKKOS_INLINE_FUNCTION
+  void Coords(int b, Real X0, Real X1, Real X2, Real X3, Real C[NDFULL]) const {
     return system_.Coords(X0, X1, X2, X3, C);
   }
   KOKKOS_INLINE_FUNCTION

--- a/src/geometry/analytic_system.hpp
+++ b/src/geometry/analytic_system.hpp
@@ -190,7 +190,8 @@ class Analytic {
     return system_.ContravariantShift(X0, X1, X2, X3, beta);
   }
   KOKKOS_INLINE_FUNCTION
-  void ContravariantShift(int b, Real X0, Real X1, Real X2, Real X3, Real beta[NDSPACE]) const {
+  void ContravariantShift(int b, Real X0, Real X1, Real X2, Real X3,
+                          Real beta[NDSPACE]) const {
     return system_.ContravariantShift(X0, X1, X2, X3, beta);
   }
   KOKKOS_INLINE_FUNCTION
@@ -213,7 +214,8 @@ class Analytic {
     return system_.Metric(X0, X1, X2, X3, gamma);
   }
   KOKKOS_INLINE_FUNCTION
-  void Metric(int b, Real X0, Real X1, Real X2, Real X3, Real gamma[NDSPACE][NDSPACE]) const {
+  void Metric(int b, Real X0, Real X1, Real X2, Real X3,
+              Real gamma[NDSPACE][NDSPACE]) const {
     return system_.Metric(X0, X1, X2, X3, gamma);
   }
   KOKKOS_INLINE_FUNCTION
@@ -260,7 +262,8 @@ class Analytic {
     return system_.SpacetimeMetric(X0, X1, X2, X3, g);
   }
   KOKKOS_INLINE_FUNCTION
-  void SpacetimeMetric(int b, Real X0, Real X1, Real X2, Real X3, Real g[NDFULL][NDFULL]) const {
+  void SpacetimeMetric(int b, Real X0, Real X1, Real X2, Real X3,
+                       Real g[NDFULL][NDFULL]) const {
     return system_.SpacetimeMetric(X0, X1, X2, X3, g);
   }
   KOKKOS_INLINE_FUNCTION

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -30,6 +30,7 @@
 #include "geometry/geometry_defaults.hpp"
 #include "geometry/geometry_utils.hpp"
 #include "phoebus_utils/cell_locations.hpp"
+#include "phoebus_utils/interpolation.hpp"
 #include "phoebus_utils/robust.hpp"
 
 using namespace parthenon::package::prelude;
@@ -126,8 +127,12 @@ class Cached {
     icoord_n_ = imap["g.n.coord"].first;
   }
   KOKKOS_INLINE_FUNCTION
+  Real Lapse(int b, Real X0, Real X1, Real X2, Real X3) const {
+    return LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].alpha);
+  }
+  KOKKOS_INLINE_FUNCTION
   Real Lapse(Real X0, Real X1, Real X2, Real X3) const {
-    return s_.Lapse(X0, X1, X2, X3);
+    return Lapse(0, X0, X1, X2, X3);
   }
   KOKKOS_INLINE_FUNCTION
   Real Lapse(CellLocation loc, int b, int k, int j, int i) const {
@@ -141,8 +146,15 @@ class Cached {
     return Lapse(loc, b_, k, j, i);
   }
   KOKKOS_INLINE_FUNCTION
+  void ContravariantShift(int b, Real X0, Real X1, Real X2, Real X3,
+                          Real beta[NDSPACE]) const {
+    SPACELOOP(d) {
+      beta[d] = LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].bcon + d);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void ContravariantShift(Real X0, Real X1, Real X2, Real X3, Real beta[NDSPACE]) const {
-    s_.ContravariantShift(X0, X1, X2, X3, beta);
+    return ContravariantShift(0, X0, X1, X2, X3, beta);
   }
   KOKKOS_INLINE_FUNCTION
   void ContravariantShift(CellLocation loc, int b, int k, int j, int i,
@@ -158,8 +170,17 @@ class Cached {
     ContravariantShift(loc, b_, k, j, i, beta);
   }
   KOKKOS_INLINE_FUNCTION
+  void Metric(int b, Real X0, Real X1, Real X2, Real X3,
+              Real gamma[NDSPACE][NDSPACE]) const {
+    SPACELOOP2(m, n) {
+      int offst = Utils::Flatten2(m + 1, n + 1, NDFULL); // gamma_{ij} = g_{ij}
+      gamma[m][n] =
+          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].gcov + Offst);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void Metric(Real X0, Real X1, Real X2, Real X3, Real gamma[NDSPACE][NDSPACE]) const {
-    return s_.Metric(X0, X1, X2, X3, gamma);
+    return Metric(0, X0, X1, X2, X3, gamma);
   }
   KOKKOS_INLINE_FUNCTION
   void Metric(CellLocation loc, int b, int k, int j, int i,
@@ -177,9 +198,18 @@ class Cached {
     Metric(loc, b_, k, j, i, gamma);
   }
   KOKKOS_INLINE_FUNCTION
+  void MetricInverse(int b, Real X0, Real X1, Real X2, Real X3,
+                     Real gamma[NDSPACE][NDSPACE]) const {
+    SPACELOOP2(m, n) {
+      int offst = Utils::Flatten2(m, n, NDSPACE);
+      gamma[m][n] =
+          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].gamcon + offst);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void MetricInverse(Real X0, Real X1, Real X2, Real X3,
                      Real gamma[NDSPACE][NDSPACE]) const {
-    return s_.MetricInverse(X0, X1, X2, X3, gamma);
+    return MetricInverse(0, X0, X1, X2, X3, gamma);
   }
   KOKKOS_INLINE_FUNCTION
   void MetricInverse(CellLocation loc, int b, int k, int j, int i,
@@ -199,7 +229,15 @@ class Cached {
   }
   KOKKOS_INLINE_FUNCTION
   void SpacetimeMetric(Real X0, Real X1, Real X2, Real X3, Real g[NDFULL][NDFULL]) const {
-    return s_.SpacetimeMetric(X0, X1, X2, X3, g);
+    SPACETIMELOOP2(mu, nu) {
+      int offst = Utils::Flatten2(mu, nu, NDFULL);
+      g[mu][nu] =
+          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].gcov + offst);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
+  void SpacetimeMetric(Real X0, Real X1, Real X2, Real X3, Real g[NDFULL][NDFULL]) const {
+    return SpacetimeMetric(0, X0, X1, X2, X3, g);
   }
   KOKKOS_INLINE_FUNCTION
   void SpacetimeMetric(CellLocation loc, int b, int k, int j, int i,
@@ -218,9 +256,27 @@ class Cached {
     SpacetimeMetric(loc, b_, k, j, i, g);
   }
   KOKKOS_INLINE_FUNCTION
+  void SpacetimeMetricInverse(int b, Real X0, Real X1, Real X2, Real X3,
+                              Real g[NDFULL][NDFULL]) const {
+    auto &idx = idx_[cent_];
+    Real alpha2 = Lapse(b, X1, X2, X3);
+    alpha2 *= alpha2;
+    g[0][0] = -robust::ratio(1, alpha2);
+    SPACELOOP(mu) {
+      Real num = LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx.bcon + mu);
+      g[mu + 1][0] = g[0][mu + 1] = ratio(num, alpha2);
+    }
+    SPACELOOP2(mu, nu) {
+      int offst = Utils::Flatten2(mu, nu, NDSPACE);
+      g[mu + 1][nu + 1] =
+          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx.gamcon + offst);
+      g[mu + 1][nu + 1] -= g[0][mu + 1] * g[0][nu + 1] * alpha2;
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void SpacetimeMetricInverse(Real X0, Real X1, Real X2, Real X3,
                               Real g[NDFULL][NDFULL]) const {
-    return s_.SpacetimeMetricInverse(X0, X1, X2, X3, g);
+    return SpacetimeMetricInverse(b, X0, X1, X2, X3, g);
   }
   KOKKOS_INLINE_FUNCTION
   void SpacetimeMetricInverse(CellLocation loc, int b, int k, int j, int i,
@@ -248,8 +304,12 @@ class Cached {
     SpacetimeMetricInverse(loc, b_, k, j, i, g);
   }
   KOKKOS_INLINE_FUNCTION
+  Real DetGamma(int b, Real X0, Real X1, Real X2, Real X3) const {
+    return LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].detgam);
+  }
+  KOKKOS_INLINE_FUNCTION
   Real DetGamma(Real X0, Real X1, Real X2, Real X3) const {
-    return s_.DetGamma(X0, X1, X2, X3);
+    return DetGamma(0, X0, X1, X2, X3);
   }
   KOKKOS_INLINE_FUNCTION
   Real DetGamma(CellLocation loc, int b, int k, int j, int i) const {
@@ -267,9 +327,16 @@ class Cached {
     return Lapse(std::forward<Args>(args)...) * DetGamma(std::forward<Args>(args)...);
   }
   KOKKOS_INLINE_FUNCTION
+  void ConnectionCoefficient(int b, Real X0, Real X1, Real X2, Real X3,
+                             Real Gamma[NDFULL][NDFULL][NDFULL]) const {
+    Real dg[NDFULL][NDFULL][NDFULL];
+    MetricDerivative(b, X0, X1, X2, X3, dg);
+    Utils::SetConnectionCoeffFromMetricDerivs(dg, Gamma);
+  }
+  KOKKOS_INLINE_FUNCTION
   void ConnectionCoefficient(Real X0, Real X1, Real X2, Real X3,
                              Real Gamma[NDFULL][NDFULL][NDFULL]) const {
-    return s_.ConnectionCoefficient(X0, X1, X2, X3, Gamma);
+    return ConnectionCoefficient(0, X0, X1, X2, X3, Gamma);
   }
   KOKKOS_INLINE_FUNCTION
   void ConnectionCoefficient(CellLocation loc, int k, int j, int i,
@@ -288,9 +355,22 @@ class Cached {
     Utils::SetConnectionCoeffByFD(*this, Gamma, loc, bid, k, j, i);
   }
   KOKKOS_INLINE_FUNCTION
+  void MetricDerivative(int b, Real X0, Real X1, Real X2, Real X3,
+                        Real dg[NDFULL][NDFULL][NDFULL]) const {
+    const int offset = !time_dependent_;
+    SPACETIMELOOP2(mu, nu) {
+      const int flat =
+        nvar_deriv_ * Utils::Flatten2(mu, nu, NDFULL) + idx_[cent_].dg - offset;
+      dg[mu][nu][0] = 0.0; // gets overwritten if time-dependent metric
+      for (int sigma = offset; sigma < NDFULL; sigma++) {
+        dg[mu][nu][sigma] = LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, flat + sigma);
+      }
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void MetricDerivative(Real X0, Real X1, Real X2, Real X3,
                         Real dg[NDFULL][NDFULL][NDFULL]) const {
-    return s_.MetricDerivative(X0, X1, X2, X3, dg);
+    return MetricDerivative(0, X0, X1, X2, X3, dg);
   }
   KOKKOS_INLINE_FUNCTION
   void MetricDerivative(CellLocation loc, int b, int k, int j, int i,
@@ -301,10 +381,10 @@ class Cached {
     const int offset = !time_dependent_;
     SPACETIMELOOP2(mu, nu) {
       const int flat =
-          nvar_deriv_ * Utils::Flatten2(mu, nu, NDFULL) + idx_[loc].dg - offset;
+          nvar_deriv_ * Utils::Flatten2(mu, nu, NDFULL) + idx_[cent_].dg - offset;
       dg[mu][nu][0] = 0.0; // gets overwritten if time-dependent metric
       for (int sigma = offset; sigma < NDFULL; sigma++) {
-        dg[mu][nu][sigma] = pack_(b, flat + sigma, k, j, i);
+        dg[mu][nu][sigma] = pack_(axisymmetric_, b, flat + sigma, k, j, i);
       }
     }
   }
@@ -314,8 +394,16 @@ class Cached {
     MetricDerivative(loc, b_, k, j, i, dg);
   }
   KOKKOS_INLINE_FUNCTION
+  void GradLnAlpha(int b, Real X0, Real X1, Real X2, Real X3, Real da[NDFULL]) const {
+    const int offset = !time_dependent_;
+    da[0] = 0; // gets overwritten if time-dependent metric
+    for (int d = offset; d < NDFULL; ++d) {
+      da[d] = LCInterp::Do(axisymmetric_, b, X1, X2, X3, idx_[cent_] + d - offset);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void GradLnAlpha(Real X0, Real X1, Real X2, Real X3, Real da[NDFULL]) const {
-    return s_.GradLnAlpha(X0, X1, X2, X3, da);
+    return GradLnAlpha(0, X0, X1, X2, X3, da);
   }
   KOKKOS_INLINE_FUNCTION
   void GradLnAlpha(CellLocation loc, int b, int k, int j, int i, Real da[NDFULL]) const {
@@ -333,8 +421,15 @@ class Cached {
     return GradLnAlpha(loc, b_, k, j, i, da);
   }
   KOKKOS_INLINE_FUNCTION
+  void Coords(int b, Real X0, Real X1, Real X2, Real X3, Real C[NDFULL]) const {
+    C[0] = X0_;
+    SPACELOOP(i) { // coords never axisymmetric
+      C[d + 1] = LCInterp::Do(b, X1, X2, X3, pack_, icoord + d);
+    }
+  }
+  KOKKOS_INLINE_FUNCTION
   void Coords(Real X0, Real X1, Real X2, Real X3, Real C[NDFULL]) const {
-    return s_.Coords(X0, X1, X2, X3, C);
+    return Coords(0, X0, X1, X2, X3, C);
   }
   KOKKOS_INLINE_FUNCTION
   void Coords(CellLocation loc, int b, int k, int j, int i, Real C[NDFULL]) const {
@@ -368,6 +463,7 @@ class Cached {
   Impl::LocArray<Impl::GeomPackIndices> idx_;
   static constexpr Real X0_ = 0;
   static constexpr int b_ = 0;
+  static constexpr CellLocation cent_ = CellLocation::Cent;
 };
 
 template <typename System>

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -33,7 +33,7 @@
 #include "geometry/geometry_defaults.hpp"
 #include "geometry/geometry_utils.hpp"
 #include "phoebus_utils/cell_locations.hpp"
-#include "phoebus_utils/interpolation.hpp"
+#include "phoebus_utils/phoebus_interpolation.hpp"
 #include "phoebus_utils/robust.hpp"
 
 using namespace parthenon::package::prelude;

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -387,7 +387,7 @@ class Cached {
     const int offset = !time_dependent_;
     SPACETIMELOOP2(mu, nu) {
       const int flat =
-          nvar_deriv_ * Utils::Flatten2(mu, nu, NDFULL) + idx_[cent_].dg - offset;
+          nvar_deriv_ * Utils::Flatten2(mu, nu, NDFULL) + idx_[loc].dg - offset;
       dg[mu][nu][0] = 0.0; // gets overwritten if time-dependent metric
       for (int sigma = offset; sigma < NDFULL; sigma++) {
         dg[mu][nu][sigma] = pack_(b, flat + sigma, k, j, i);

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -158,7 +158,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real det_ca = geom_cached.DetGamma(b, X0, X1, X2, X3);
         diff = RelErr(det_an, det_ca);
         le = std::max(le, diff);
-        
+
         // Metric derivative (Connection for free since it's computed
         // from metric derivative)
         Real dg_an[NDFULL][NDFULL][NDFULL];

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -92,12 +92,12 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
       KOKKOS_LAMBDA(const int k, const int j, const int i, Real &le) {
         // Try to interpolate a little offset from the cell center in
         // each direction.
-        const Real dx1 = 0.5 * coords.Dx(X1DIR);
-        const Real dx2 = 0.5 * coords.Dx(X2DIR);
-        const Real dx3 = 0.5 * coords.Dx(X3DIR);
+        const Real dx1 = 0.25 * coords.Dx(X1DIR);
+        const Real dx2 = 0.25 * coords.Dx(X2DIR);
+        const Real dx3 = 0.25 * coords.Dx(X3DIR);
         Real X1 = coords.x1v(k, j, i) + dx1;
         Real X2 = coords.x2v(k, j, i) + dx2;
-        Real X3 = coords.x3v(k, j, i);// + dx3;
+        Real X3 = coords.x3v(k, j, i) + dx3;
 
         Real diff;
 

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -87,7 +87,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
   kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);
   pmb->par_reduce(
-      "Phoebus::ProblemGenerator::CheckCachedGeometry::Grads", kb.s, kb.e, jb.s, jb.e,
+      "Phoebus::ProblemGenerator::CheckCachedGeometry::interps", kb.s, kb.e, jb.s, jb.e,
       ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i, Real &le) {
         // Try to interpolate a little offset from the cell center in

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -79,6 +79,8 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
       Kokkos::Max<Real>(max_err));
   printf("Maximum error in gradients = %.14e\n", max_err);
 
+  const int b = 0;
+  const int X0 = 0;
   auto coords = pmb->coords;
   ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
@@ -92,9 +94,15 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real dx1 = 0.5 * coords.Dx(X1DIR);
         const Real dx2 = 0.5 * coords.Dx(X2DIR);
         const Real dx3 = 0.5 * coords.Dx(X3DIR);
-        Real X1 = coords.X1v(k, j, i) + dx1;
-        Real X2 = coords.X2v(k, j, i) + dx2;
-        Real X3 = coords.X3v(k, j, i) + dx3;
+        Real X1 = coords.x1v(k, j, i) + dx1;
+        Real X2 = coords.x2v(k, j, i) + dx2;
+        Real X3 = coords.x3v(k, j, i) + dx3;
+
+        // Lapse
+        const Real alp_an = geom_analytic.Lapse(b, X0, X1, X2, X3);
+        const Real alp_ca = geom_cached.Lapse(b, X0, X1, X2, X3);
+        le += std::max(le, RelErr(alp_an, alp_ca));
+
         
       },
       Kokkos::Max<Real>(max_err));

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -52,7 +52,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  Real max_err;
+  Real max_err_grad = 0;
   auto loc = CellLocation::Cent;
   pmb->par_reduce(
       "Phoebus::ProblemGenerator::CheckCachedGeometry::Grads", kb.s, kb.e, jb.s, jb.e,
@@ -76,9 +76,10 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
           le = std::max(le, diff);
         }
       },
-      Kokkos::Max<Real>(max_err));
-  printf("Maximum error in gradients = %.14e\n", max_err);
+      Kokkos::Max<Real>(max_err_grad));
+  printf("Maximum error in gradients = %.14e\n", max_err_grad);
 
+  Real max_err_interp = 0;
   const int b = 0;
   const int X0 = 0;
   auto coords = pmb->coords;
@@ -96,16 +97,91 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real dx3 = 0.5 * coords.Dx(X3DIR);
         Real X1 = coords.x1v(k, j, i) + dx1;
         Real X2 = coords.x2v(k, j, i) + dx2;
-        Real X3 = coords.x3v(k, j, i) + dx3;
+        Real X3 = coords.x3v(k, j, i);// + dx3;
+
+        Real diff;
 
         // Lapse
         const Real alp_an = geom_analytic.Lapse(b, X0, X1, X2, X3);
         const Real alp_ca = geom_cached.Lapse(b, X0, X1, X2, X3);
-        le += std::max(le, RelErr(alp_an, alp_ca));
+        diff = RelErr(alp_an, alp_ca);
+        le = std::max(le, diff);
 
+        // Shift
+        Real beta_an[NDSPACE];
+        Real beta_ca[NDSPACE];
+        geom_analytic.ContravariantShift(b, X0, X1, X2, X3, beta_an);
+        geom_cached.ContravariantShift(b, X0, X1, X2, X3, beta_ca);
+        SPACELOOP(d) {
+          diff = RelErr(beta_an[d], beta_ca[d]);
+          le = std::max(le, diff);
+        }
+
+        // spatial Metric
+        Real gam_an[NDSPACE][NDSPACE];
+        Real gam_ca[NDSPACE][NDSPACE];
+        geom_analytic.Metric(b, X0, X1, X2, X3, gam_an);
+        geom_cached.Metric(b, X0, X1, X2, X3, gam_ca);
+        SPACELOOP2(m, n) {
+          diff = RelErr(gam_an[m][n], gam_ca[m][n]);
+          le = std::max(le, diff);
+        }
+
+        // Spatial metric inverse
+        geom_analytic.MetricInverse(b, X0, X1, X2, X3, gam_an);
+        geom_cached.MetricInverse(b, X0, X1, X2, X3, gam_ca);
+        SPACELOOP2(m, n) {
+          diff = RelErr(gam_an[m][n], gam_ca[m][n]);
+          le = std::max(le, diff);
+        }
+
+        // Spacetime metric
+        Real g_an[NDFULL][NDFULL];
+        Real g_ca[NDFULL][NDFULL];
+        geom_analytic.SpacetimeMetric(b, X0, X1, X2, X3, g_an);
+        geom_cached.SpacetimeMetric(b, X0, X1, X2, X3, g_ca);
+        SPACETIMELOOP2(m, n) {
+          diff = RelErr(g_an[m][n], g_ca[m][n]);
+          le = std::max(le, diff);
+        }
+
+        // Spacetime metric inverse
+        geom_analytic.SpacetimeMetricInverse(b, X0, X1, X2, X3, g_an);
+        geom_cached.SpacetimeMetricInverse(b, X0, X1, X2, X3, g_ca);
+        SPACETIMELOOP2(m, n) {
+          diff = RelErr(g_an[m][n], g_ca[m][n]);
+          le = std::max(le, diff);
+        }
+
+        // DetGamma (DetG is for free since it uses lapse * detgamma)
+        const Real det_an = geom_analytic.DetGamma(b, X0, X1, X2, X3);
+        const Real det_ca = geom_cached.DetGamma(b, X0, X1, X2, X3);
+        diff = RelErr(det_an, det_ca);
+        le = std::max(le, diff);
         
+        // Metric derivative (Connection for free since it's computed
+        // from metric derivative)
+        Real dg_an[NDFULL][NDFULL][NDFULL];
+        Real dg_ca[NDFULL][NDFULL][NDFULL];
+        geom_analytic.MetricDerivative(b, X0, X1, X2, X3, dg_an);
+        geom_cached.MetricDerivative(b, X0, X1, X2, X3, dg_ca);
+        SPACETIMELOOP3(m, n, s) {
+          diff = RelErr(dg_an[m][n][s], dg_ca[m][n][s]);
+          le = std::max(le, diff);
+        }
+
+        // GradLnAlpha
+        Real da_an[NDFULL];
+        Real da_ca[NDFULL];
+        geom_analytic.GradLnAlpha(b, X0, X1, X2, X3, da_an);
+        geom_cached.GradLnAlpha(b, X0, X1, X2, X3, da_ca);
+        SPACETIMELOOP(d) {
+          diff = RelErr(da_an[d], da_ca[d]);
+          le = std::max(le, diff);
+        }
       },
-      Kokkos::Max<Real>(max_err));
+      Kokkos::Max<Real>(max_err_interp));
+  printf("Maximum error in interpolation = %.14e\n", max_err_interp);
 
   std::exit(1);
 }

--- a/src/phoebus_utils/grid_utils.hpp
+++ b/src/phoebus_utils/grid_utils.hpp
@@ -1,0 +1,58 @@
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#ifndef PHOEBUS_UTILS_GRID_UTILS_HPP_
+#define PHOEBUS_UTILS_GRID_UTILS_HPP_
+
+// Parthenon includes
+#include <coordinates/coordinates.hpp>
+#include <kokkos_abstraction.hpp>
+#include <parthenon/package.hpp>
+#include <utils/error_checking.hpp>
+
+namespace Coordinates {
+
+using namespace parthenon::package::prelude;
+using parthenon::Coordinates_t;
+
+template <int dir>
+KOKKOS_FORCEINLINE_FUNCTION Real GetXf(const int i, const Coordinates_t &coord);
+template <>
+KOKKOS_FORCEINLINE_FUNCTION Real GetXf<X1DIR>(const int i, const Coordinates_t &coord) {
+  return coord.x1f(i);
+}
+template <>
+KOKKOS_FORCEINLINE_FUNCTION Real GetXf<X2DIR>(const int i, const Coordinates_t &coord) {
+  return coord.x2f(i);
+}
+template <>
+KOKKOS_FORCEINLINE_FUNCTION Real GetXf<X3DIR>(const int i, const Coordinates_t &coord) {
+  return coord.x3f(i);
+}
+KOKKOS_FORCEINLINE_FUNCTION Real GetXf(const int i, const int dir,
+                                       const Coordinates_t &coord) {
+  switch (dir) {
+  case X1DIR:
+    return GetXf<X1DIR>(i, coord);
+  case X2DIR:
+    return GetXf<X2DIR>(i, coord);
+  case X3DIR:
+    return GetXf<X3DIR>(i, coord);
+  default:
+    PARTHENON_FAIL("Invalid coordinate direction");
+  }
+}
+
+} // namespace Coordinates
+
+#endif // PHOEBUS_UTILS_GRID_UTILS_HPP_

--- a/src/phoebus_utils/grid_utils.hpp
+++ b/src/phoebus_utils/grid_utils.hpp
@@ -26,28 +26,28 @@ using namespace parthenon::package::prelude;
 using parthenon::Coordinates_t;
 
 template <int dir>
-KOKKOS_FORCEINLINE_FUNCTION Real GetXf(const int i, const Coordinates_t &coord);
+KOKKOS_FORCEINLINE_FUNCTION Real GetXv(const int i, const Coordinates_t &coord);
 template <>
-KOKKOS_FORCEINLINE_FUNCTION Real GetXf<X1DIR>(const int i, const Coordinates_t &coord) {
-  return coord.x1f(i);
+KOKKOS_FORCEINLINE_FUNCTION Real GetXv<X1DIR>(const int i, const Coordinates_t &coord) {
+  return coord.x1v(i);
 }
 template <>
-KOKKOS_FORCEINLINE_FUNCTION Real GetXf<X2DIR>(const int i, const Coordinates_t &coord) {
-  return coord.x2f(i);
+KOKKOS_FORCEINLINE_FUNCTION Real GetXv<X2DIR>(const int i, const Coordinates_t &coord) {
+  return coord.x2v(i);
 }
 template <>
-KOKKOS_FORCEINLINE_FUNCTION Real GetXf<X3DIR>(const int i, const Coordinates_t &coord) {
-  return coord.x3f(i);
+KOKKOS_FORCEINLINE_FUNCTION Real GetXv<X3DIR>(const int i, const Coordinates_t &coord) {
+  return coord.x3v(i);
 }
-KOKKOS_FORCEINLINE_FUNCTION Real GetXf(const int i, const int dir,
+KOKKOS_FORCEINLINE_FUNCTION Real GetXv(const int i, const int dir,
                                        const Coordinates_t &coord) {
   switch (dir) {
   case X1DIR:
-    return GetXf<X1DIR>(i, coord);
+    return GetXv<X1DIR>(i, coord);
   case X2DIR:
-    return GetXf<X2DIR>(i, coord);
+    return GetXv<X2DIR>(i, coord);
   case X3DIR:
-    return GetXf<X3DIR>(i, coord);
+    return GetXv<X3DIR>(i, coord);
   default:
     PARTHENON_FAIL("Invalid coordinate direction");
   }

--- a/src/phoebus_utils/interpolation.hpp
+++ b/src/phoebus_utils/interpolation.hpp
@@ -101,8 +101,13 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Pack &
   weights_t w1, w2;
   GetWeights<X1DIR>(X1, p.GetDim(1), coords, ix1, w1);
   GetWeights<X2DIR>(X2, p.GetDim(2), coords, ix2, w2);
-  return (w2[0] * (w1[0] * p(b, v, ix2, ix1) + w1[1] * p(b, v, ix2, ix1 + 1)) +
-          w2[1] * (w1[0] * p(b, v, ix2 + 1, ix1) + w1[1] * (b, v, ix2 + 1, ix1 + 1)));
+  // printf("\tInterp2D: %d %d %.14e %.14e %.14e %.14e\n",
+  //        ix1, ix2,
+  //        p(b, v, 0, ix2, ix1), p(b, v, 0, ix2, ix1 + 1),
+  //        p(b, v, 0, ix2 + 1, ix1), p(b, v, 0, ix2 + 1, ix1 + 1));
+  return (w2[0] * (w1[0] * p(b, v, 0, ix2, ix1) + w1[1] * p(b, v, 0, ix2, ix1 + 1)) +
+          w2[1] *
+              (w1[0] * p(b, v, 0, ix2 + 1, ix1) + w1[1] * p(b, v, 0, ix2 + 1, ix1 + 1)));
 }
 
 /*

--- a/src/phoebus_utils/interpolation.hpp
+++ b/src/phoebus_utils/interpolation.hpp
@@ -15,7 +15,7 @@
 #define PHOEBUS_UTILS_INTERPOLATION_HPP_
 
 // Spiner includes
-#include <spiner/interpoaltion.hpp>
+#include <spiner/interpolation.hpp>
 
 // Parthenon includes
 #include <coordinates/coordinates.hpp>
@@ -36,7 +36,7 @@ using Spiner::weights_t;
 // alternative path would be a class called "LCInterp with all
 // static functions. Then it could have an `operator()` which would
 // be maybe nicer?
-
+// TODO(JMM): Merge this w/ what Ben has done.
 namespace Cent {
 namespace Linear {
 
@@ -73,9 +73,9 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X
   const auto &coords = p.GetCoords(b);
   int ix[3];
   weights_t w[3];
-  GetWeights(X1, p.GetDim(1), coords, ix[0], w[0]);
-  GetWeights(X2, p.GetDim(2), coords, ix[1], w[1]);
-  GetWeights(X3, p.GetDim(3), coords, ix[2], w[2]);
+  GetWeights<X1DIR>(X1, p.GetDim(1), coords, ix[0], w[0]);
+  GetWeights<X2DIR>(X2, p.GetDim(2), coords, ix[1], w[1]);
+  GetWeights<X3DIR>(X3, p.GetDim(3), coords, ix[2], w[2]);
   return (w[2][0] * (w[1][0] * (w[0][0] * p(b, v, ix[2], ix[1], ix[0]) +
                                 w[0][1] * p(b, v, ix[2], ix[1], ix[0] + 1)) +
                      w[1][1] * (w[0][0] * p(b, v, ix[2], ix[1] + 1, ix[0]) +
@@ -99,8 +99,8 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Pack &
   const auto &coords = p.GetCoords(b);
   int ix1, ix2;
   weights_t w1, w2;
-  GetWeights(X1, p.GetDim(1), coords, ix1, w1);
-  GetWeights(X2, p.GetDim(2), coords, ix2, w2);
+  GetWeights<X1DIR>(X1, p.GetDim(1), coords, ix1, w1);
+  GetWeights<X2DIR>(X2, p.GetDim(2), coords, ix2, w2);
   return (w2[0] * (w1[0] * p(b, v, ix2, ix1) + w1[1] * p(b, v, ix2, ix1 + 1)) +
           w2[1] * (w1[0] * p(b, v, ix2 + 1, ix1) + w1[1] * (b, v, ix2 + 1, ix1 + 1)));
 }
@@ -133,6 +133,6 @@ KOKKOS_INLINE_FUNCTION Real Do(bool axisymmetric, int b, const Real X1, const Re
 } // namespace Interpolation
 
 // Convenience Namespace Alias
-namespace LCInterp = Interpolation::Cent::Lin;
+namespace LCInterp = Interpolation::Cent::Linear;
 
 #endif // PHOEBUS_UTILS_INTERPOLATION_HPP_

--- a/src/phoebus_utils/interpolation.hpp
+++ b/src/phoebus_utils/interpolation.hpp
@@ -1,0 +1,104 @@
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#ifndef PHOEBUS_UTILS_INTERPOLATION_HPP_
+#define PHOEBUS_UTILS_INTERPOLATION_HPP_
+
+// Spiner includes
+#include <spiner/interpoaltion.hpp>
+
+// Parthenon includes
+#include <coordinates/coordinates.hpp>
+#include <kokkos_abstraction.hpp>
+#include <parthenon/package.hpp>
+
+// Phoebus includes
+#include "phoebus_utils/grid_utils.hpp"
+#include "phoebus_utils/robust.hpp"
+
+namespace Interpolation {
+
+using namespace parthenon::package::prelude;
+using parthenon::Coordinates_t;
+using Spiner::weights_t;
+
+namespace Nodes {
+namespace Linear {
+
+/*
+ * Get interpolation weights for linear interpolation
+ * PARAM[IN] - x - location to interpolate to
+ * PARAM[IN] - nx - number of points along this direction. Used for sanity checks.
+ * PARAM[IN] - coords - parthenon coords object
+ * PARAM[OUT] - ix - index of points to interpolate
+ * PARAM[OUT] - w - weights
+ */
+template <int DIR>
+KOKKOS_INLINE_FUNCTION void GetWeights(const Real x, const int nx,
+                                       const Coordinates_t &coords, int &ix,
+                                       weights_t &w) {
+  const Real min = Coordniates::GetXf<DIR>(0, coords);
+  const Real dx = coords.Dx(DIR);
+  ix = std::min(std::max(0, static_cast<int>(robust::ratio(x - min, dx))), nx - 2);
+  const Real floor = min + ix * dx;
+  w[1] = robust::ratio(x - floor, dx);
+  w[0] = 1. - w[1];
+}
+
+/*
+ * Trilinear interpolation on a variable or meshblock pack
+ * PARAM[IN] - X3, X2, X1: Coordinate locations
+ * PARAM[IN] - nx3, nx2, nx1 - number of points along each direction
+ * PARAM[IN] - coords - parthenon coords object
+ * PARAM[IN] - p - Variable or MeshBlockPack
+ * PARAM[IN] - b, v, variable and meshblock index
+ */
+template <typename Pack>
+KOKKOS_INLINE_FUNCTION Real Do(const Real X3, const Real X2, const Real X1,
+                               const int nx3, const int nx2, const int nx1,
+                               const Coordinates_t &coords, const Pack &p, int b, int v) {
+  int ix[3];
+  weights_t w[3];
+  GetWeights(X1, nx1, coords, ix[0], w[0]);
+  GetWeights(X2, nx2, coords, ix[1], w[1]);
+  GetWeights(X3, nx3, coords, ix[2], w[2]);
+  return (w[2][0] * (w[1][0] * (w[0][0] * p(b, v, ix[2], ix[1], ix[0]) +
+                                w[0][1] * p(b, v, ix[2], ix[1], ix[0] + 1)) +
+                     w[1][1] * (w[0][0] * p(b, v, ix[2], ix[1] + 1, ix[0]) +
+                                w[0][1] * p(b, v, ix[2], ix[1] + 1, ix[0] + 1))) +
+          w[2][1] * (w[1][0] * (w[0][0] * p(b, v, ix[2] + 1, ix[1], ix[0]) +
+                                w[0][1] * p(b, v, ix[2] + 1, ix[1], ix[0] + 1)) +
+                     w[1][1] * (w[0][0] * p(b, v, ix[2] + 1, ix[1] + 1, ix[0]) +
+                                w[0][1] * p(b, v, ix[2] + 1, ix[1] + 1, ix[0] + 1))));
+}
+
+/*
+ * Trilinear interpolation on a variable or meshblock pack
+ * PARAM[IN] - X3, X2, X1: Coordinate locations
+ * PARAM[IN] - nx3, nx2, nx1 - number of points along each direction
+ * PARAM[IN] - coords - parthenon coords object
+ * PARAM[IN] - p - Variable or MeshBlockPack
+ * PARAM[IN] - b, v, variable and meshblock index
+ */
+template <typename Pack>
+KOKKOS_INLINE_FUNCTION Real Do(const Real X3, const Real X2, const Real X1,
+                               const int nx3, const int nx2, const int nx1,
+                               const Coordinates_t &coords, const Pack &p, int v) {
+  return Do(x3, x2, x1, nx3, nx2, nx1, coords, p, v);
+}
+
+} // namespace Linear
+} // namespace Nodes
+} // namespace Interpolation
+
+#endif // PHOEBUS_UTILS_INTERPOLATION_HPP_

--- a/src/phoebus_utils/interpolation.hpp
+++ b/src/phoebus_utils/interpolation.hpp
@@ -86,17 +86,23 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X
                                 w[0][1] * p(b, v, ix[2] + 1, ix[1] + 1, ix[0] + 1))));
 }
 
+/*
+ * Trilinear interpolation on a variable or meshblock pack
+ * PARAM[IN] - b - Meshblock index
+ * PARAM[IN] - X1, X2, X3 - Coordinate locations
+ * PARAM[IN] - p - Variable or MeshBlockPack
+ * PARAM[IN] - v - variable index
+ */
 template <typename Pack>
-KOKKOS_INLINE_FUNCTION Real DataBox::interpToReal(int b, const Real X1, const Real X2,
-                                                  const Pack &p, int v) {
-  assert(canInterpToReal_(2));
+KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Pack &p,
+                               int v) {
+  const auto &coords = p.GetCoords(b);
   int ix1, ix2;
   weights_t w1, w2;
-  grids_[0].weights(x1, ix1, w1);
-  grids_[1].weights(x2, ix2, w2);
-  return (w2[0] * (w1[0] * dataView_(ix2, ix1) + w1[1] * dataView_(ix2, ix1 + 1)) +
-          w2[1] *
-              (w1[0] * dataView_(ix2 + 1, ix1) + w1[1] * dataView_(ix2 + 1, ix1 + 1)));
+  GetWeights(X1, p.GetDim(1), coords, ix1, w1);
+  GetWeights(X2, p.GetDim(2), coords, ix2, w2);
+  return (w2[0] * (w1[0] * p(b, v, ix2, ix1) + w1[1] * p(b, v, ix2, ix1 + 1)) +
+          w2[1] * (w1[0] * p(b, v, ix2 + 1, ix1) + w1[1] * (b, v, ix2 + 1, ix1 + 1)));
 }
 
 /*

--- a/src/phoebus_utils/phoebus_interpolation.hpp
+++ b/src/phoebus_utils/phoebus_interpolation.hpp
@@ -11,8 +11,8 @@
 // distribute copies to the public, perform publicly and display
 // publicly, and to permit others to do so.
 
-#ifndef PHOEBUS_UTILS_INTERPOLATION_HPP_
-#define PHOEBUS_UTILS_INTERPOLATION_HPP_
+#ifndef PHOEBUS_UTILS_PHOEBUS_INTERPOLATION_HPP_
+#define PHOEBUS_UTILS_PHOEBUS_INTERPOLATION_HPP_
 
 // Spiner includes
 #include <spiner/interpolation.hpp>
@@ -140,4 +140,4 @@ KOKKOS_INLINE_FUNCTION Real Do(bool axisymmetric, int b, const Real X1, const Re
 // Convenience Namespace Alias
 namespace LCInterp = Interpolation::Cent::Linear;
 
-#endif // PHOEBUS_UTILS_INTERPOLATION_HPP_
+#endif // PHOEBUS_UTILS_PHOEBUS_INTERPOLATION_HPP_

--- a/src/phoebus_utils/phoebus_interpolation.hpp
+++ b/src/phoebus_utils/phoebus_interpolation.hpp
@@ -87,9 +87,9 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X
 }
 
 /*
- * Trilinear interpolation on a variable or meshblock pack
+ * Bilinear interpolation on a variable or meshblock pack
  * PARAM[IN] - b - Meshblock index
- * PARAM[IN] - X1, X2, X3 - Coordinate locations
+ * PARAM[IN] - X1, X2 - Coordinate locations
  * PARAM[IN] - p - Variable or MeshBlockPack
  * PARAM[IN] - v - variable index
  */
@@ -101,10 +101,6 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Pack &
   weights_t w1, w2;
   GetWeights<X1DIR>(X1, p.GetDim(1), coords, ix1, w1);
   GetWeights<X2DIR>(X2, p.GetDim(2), coords, ix2, w2);
-  // printf("\tInterp2D: %d %d %.14e %.14e %.14e %.14e\n",
-  //        ix1, ix2,
-  //        p(b, v, 0, ix2, ix1), p(b, v, 0, ix2, ix1 + 1),
-  //        p(b, v, 0, ix2 + 1, ix1), p(b, v, 0, ix2 + 1, ix1 + 1));
   return (w2[0] * (w1[0] * p(b, v, 0, ix2, ix1) + w1[1] * p(b, v, 0, ix2, ix1 + 1)) +
           w2[1] *
               (w1[0] * p(b, v, 0, ix2 + 1, ix1) + w1[1] * p(b, v, 0, ix2 + 1, ix1 + 1)));

--- a/tst/unit/geometry/CMakeLists.txt
+++ b/tst/unit/geometry/CMakeLists.txt
@@ -35,14 +35,17 @@ add_library(geometry_unit_tests OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/geometry/spherical_kerr_schild.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/geometry/spherical_minkowski.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/geometry/spherical_minkowski.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/phoebus_utils/phoebus_interpolation.hpp
 
 )
 
 target_link_libraries(geometry_unit_tests
   PRIVATE
-    parthenon
-    Catch2::Catch2
-    Kokkos::kokkos)
+  parthenon
+  singularity-eos::flags
+  singularity-eos
+  Catch2::Catch2
+  Kokkos::kokkos)
 
 target_include_directories(geometry_unit_tests PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/../../../src"

--- a/tst/unit/radiation/CMakeLists.txt
+++ b/tst/unit/radiation/CMakeLists.txt
@@ -19,9 +19,11 @@ add_library(radiation_unit_tests OBJECT
 
 target_link_libraries(radiation_unit_tests
   PRIVATE
-    parthenon
-    Catch2::Catch2
-    Kokkos::kokkos)
+  parthenon
+  singularity-eos::flags
+  singularity-eos
+  Catch2::Catch2
+  Kokkos::kokkos)
 
 target_include_directories(radiation_unit_tests PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/../../../src"


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This is the final piece needed before I embark on Cartesian Monopole. This introduces the ability in the cached coordinate system to compute values off of cell centers/faces via interpolation, rather than falling back to the underlying analytic formulae. For particles this could be significantly cheaper, and it is necessary when gradients are computed by finite differences on the grid.

I enhanced my `check_cached_geom` problem generator to also check interpolations and checked against spherical Kerr-Schild and FLRW coordinates, and things seem to converge nicely.

One word of warning: coordinate singularities, such as at the poles, appear to cause problems (unsurprisingly)---the method still converges, but the convergence degrade as you move towards the singularity. Caution should be taken when using this machinery near a coordinate singularity.

For now I think we punt this issue, but we may want to do something special near the poles when running in spherical coordinates if we discover problems.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
