### PR TITLE
MonopoleCart rewrite

### DIFF
--- a/cmake/Geometry.cmake
+++ b/cmake/Geometry.cmake
@@ -1,4 +1,4 @@
-# © 2021. Triad National Security, LLC. All rights reserved.  This
+# © 2021-2022. Triad National Security, LLC. All rights reserved.  This
 # program was produced under U.S. Government contract 89233218CNA000001
 # for Los Alamos National Laboratory (LANL), which is operated by Triad
 # National Security, LLC for the U.S.  Department of Energy/National

--- a/cmake/Geometry.cmake
+++ b/cmake/Geometry.cmake
@@ -31,28 +31,11 @@ set(PHOEBUS_ANALYTIC_GEOMETRIES
     "MonopoleCart"
     )
 
-# List geometries that should not be cached here
-set(PHOEBUS_GEOMETRY_NO_CACHE
-  # "MonopoleSph"
-  )
-
-# List geometries that MUST be cached here
-set(PHOEBUS_GEOMETRY_MUST_CACHE
-  # "MonopoleCart"
-  )
-
 if(PHOEBUS_ANALYTIC_GEOMETRY)
   if (PHOEBUS_GEOMETRY IN_LIST PHOEBUS_ANALYTIC_GEOMETRIES)
     set(GEOMETRY_MESH "Analytic<${PHOEBUS_GEOMETRY}, IndexerMesh>")
     set(GEOMETRY_MESH_BLOCK "Analytic<${PHOEBUS_GEOMETRY}, IndexerMeshBlock>")
-    if (PHOEBUS_GEOMETRY IN_LIST PHOEBUS_GEOMETRY_MUST_CACHE)
-      message(WARNING "The selected geometry must be cached. Enabling cache.")
-      set(PHOEBUS_CACHE_GEOMETRY ON CACHE BOOL "Force geometry to be cached" FORCE)
-    endif()
     if (PHOEBUS_CACHE_GEOMETRY)
-      if (PHOEBUS_GEOMETRY IN_LIST PHOEBUS_GEOMETRY_NO_CACHE)
-	message(FATAL_ERROR "The selected geometry does not support caching.")
-      endif()
       set(GEOMETRY_MESH "CachedOverMesh<${GEOMETRY_MESH}>")
       set(GEOMETRY_MESH_BLOCK "CachedOverMeshBlock<${GEOMETRY_MESH_BLOCK}>")
     endif()

--- a/cmake/Geometry.cmake
+++ b/cmake/Geometry.cmake
@@ -16,6 +16,7 @@ option(PHOEBUS_CACHE_GEOMETRY "Cache geometry. Only available for some geometrie
 # Default
 set(PHOEBUS_GEOMETRY "Minkowski" CACHE STRING "The metric used by Phoebus")
 
+# List analytic geometries here.
 set(PHOEBUS_ANALYTIC_GEOMETRIES
     "Minkowski"
     "BoostedMinkowski"
@@ -29,19 +30,28 @@ set(PHOEBUS_ANALYTIC_GEOMETRIES
     "MonopoleSph"
     "MonopoleCart"
     )
+
+# List geometries that should not be cached here
 set(PHOEBUS_GEOMETRY_NO_CACHE
-    "MonopoleSph"
-    "MonopoleCart"
+
     )
+
+# List geometries that MUST be cached here
+set(PHOEBUS_GEOMETRY_MUST_CACHE
+  "MonopoleCart"
+  )
 
 if(PHOEBUS_ANALYTIC_GEOMETRY)
   if (PHOEBUS_GEOMETRY IN_LIST PHOEBUS_ANALYTIC_GEOMETRIES)
     set(GEOMETRY_MESH "Analytic<${PHOEBUS_GEOMETRY}, IndexerMesh>")
     set(GEOMETRY_MESH_BLOCK "Analytic<${PHOEBUS_GEOMETRY}, IndexerMeshBlock>")
+    if (PHOEBUS_GEOMETRY IN_LIST PHOEBUS_GEOMETRY_MUST_CACHE)
+      message(WARNING "The selected geometry must be cached. Enabling cache.")
+      set(PHOEBUS_CACHE_GEOMETRY ON CACHE BOOL "Force geometry to be cached" FORCE)
+    endif()
     if (PHOEBUS_CACHE_GEOMETRY)
       if (PHOEBUS_GEOMETRY IN_LIST PHOEBUS_GEOMETRY_NO_CACHE)
-	message(WARNING "The selected geometry does not support caching. "
-	  "You may experience unexpected behaviour.")
+	message(FATAL_ERROR "The selected geometry does not support caching.")
       endif()
       set(GEOMETRY_MESH "CachedOverMesh<${GEOMETRY_MESH}>")
       set(GEOMETRY_MESH_BLOCK "CachedOverMeshBlock<${GEOMETRY_MESH_BLOCK}>")

--- a/cmake/Geometry.cmake
+++ b/cmake/Geometry.cmake
@@ -33,12 +33,12 @@ set(PHOEBUS_ANALYTIC_GEOMETRIES
 
 # List geometries that should not be cached here
 set(PHOEBUS_GEOMETRY_NO_CACHE
-
-    )
+  # "MonopoleSph"
+  )
 
 # List geometries that MUST be cached here
 set(PHOEBUS_GEOMETRY_MUST_CACHE
-  "MonopoleCart"
+  # "MonopoleCart"
   )
 
 if(PHOEBUS_ANALYTIC_GEOMETRY)

--- a/inputs/blast_wave.pin
+++ b/inputs/blast_wave.pin
@@ -18,6 +18,8 @@
 
 <phoebus>
 problem = sedov
+ix2_bc = reflect
+ox2_bc = reflect
 
 <parthenon/job>
 problem_id  = sedov       # problem ID: basename of output filenames
@@ -59,8 +61,8 @@ ox1_bc      = user        # Outer-X1 boundary condition flag
 nx2         = 1             # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 3.14159265359 # maximum value of X2. Pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/bondi.pin
+++ b/inputs/bondi.pin
@@ -14,6 +14,8 @@
 problem = bondi
 ix1_bc = outflow
 ox1_bc = outflow
+ix2_bc = reflect
+ox2_bc = reflect
 
 <parthenon/job>
 problem_id  = bondi       # problem ID: basename of output filenames
@@ -55,8 +57,8 @@ ox1_bc      = user          # Outer-X1 boundary condition flag
 nx2         = 1             # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 1 #3.14159265359 #1 # maximum value of X2. Pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/mhd_shocktube.pin
+++ b/inputs/mhd_shocktube.pin
@@ -12,6 +12,8 @@
 
 <phoebus>
 problem   = shock_tube
+ix1_bc = outflow
+ox1_bc = outflow
 
 <parthenon/job>
 problem_id  = sod       # problem ID: basename of output filenames
@@ -44,8 +46,8 @@ nghost = 4
 nx1         = 256       # Number of zones in X1-direction
 x1min       = 0        # minimum value of X1
 x1max       = 1         # maximum value of X1
-ix1_bc      = outflow  # Inner-X1 boundary condition flag
-ox1_bc      = outflow  # Outer-X1 boundary condition flag
+ix1_bc      = user     # Inner-X1 boundary condition flag
+ox1_bc      = user     # Outer-X1 boundary condition flag
 
 nx2         = 1       # Number of zones in X2-direction
 x2min       = -1        # minimum value of X2

--- a/inputs/rhs_tester.pin
+++ b/inputs/rhs_tester.pin
@@ -14,6 +14,10 @@
 
 <phoebus>
 problem = rhs_tester
+ix1_bc = reflect
+ox1_bc = outflow
+ix2_bc = reflect
+ox2_bc = reflect
 
 <parthenon/job>
 problem_id  = test       # problem ID: basename of output filenames
@@ -55,8 +59,8 @@ ox1_bc      = user        # Outer-X1 boundary condition flag
 nx2         = 1             # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 3.14159265359 # maximum value of X2. Pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/spherical_shock_tube.pin
+++ b/inputs/spherical_shock_tube.pin
@@ -24,6 +24,10 @@
 
 <phoebus>
 problem = shock_tube
+ix1_bc = reflect
+ox1_bc = outflow
+ix2_bc = reflect
+ox2_bc = reflect
 
 <parthenon/job>
 problem_id  = sedov       # problem ID: basename of output filenames
@@ -81,8 +85,8 @@ ox1_bc      = user        # Outer-X1 boundary condition flag
 nx2         = 1             # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 3.14159265359 # maximum value of X2. Pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -3,6 +3,8 @@
 problem = torus
 ix1_bc = outflow
 ox1_bc = outflow
+ix2_bc = reflect
+ox2_bc = reflect
 
 <phoebus/mesh>
 bc_vars = primitive
@@ -56,8 +58,8 @@ ox1_bc      = user          # Outer-X1 boundary condition flag
 nx2         = 256           # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 1             # maximum value of X2. X2 = 1 -> theta = pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/torus_cutout.pin
+++ b/inputs/torus_cutout.pin
@@ -3,6 +3,8 @@
 problem = torus
 ix1_bc = outflow
 ox1_bc = outflow
+ix2_bc = reflect
+ox2_bc = reflect
 
 <parthenon/job>
 problem_id  = torus       # problem ID: basename of output filenames
@@ -53,8 +55,8 @@ ox1_bc      = user          # Outer-X1 boundary condition flag
 nx2         = 128           # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 1             # maximum value of X2. X2 = 1 -> theta = pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/tov.pin
+++ b/inputs/tov.pin
@@ -43,6 +43,10 @@ variables = p.density,  &
 file_type   = hdf5      # Tabular data dump
 dt          = 5         # time increment between outputs
 
+<parthenon/output2>
+file_type = hst
+dt = 1
+
 <parthenon/time>
 nlim        = -1        # cycle limit
 tlim        = 5000      # time limit

--- a/inputs/tov.pin
+++ b/inputs/tov.pin
@@ -16,6 +16,8 @@
 problem = tov
 ix1_bc = reflect
 ox1_bc = outflow
+ix2_bc = reflect
+ox2_bc = reflect
 
 <parthenon/job>
 problem_id  = tov # problem ID: basename of output filenames
@@ -68,8 +70,8 @@ ox1_bc      = user        # Outer-X1 boundary condition flag
 nx2         = 1             # Number of zones in X2-direction
 x2min       = 0             # minimum value of X2
 x2max       = 3.14159265359 # maximum value of X2. Pi
-ix2_bc      = reflecting    # Inner-X2 boundary condition flag
-ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 1             # Number of zones in X3-direction
 x3min       = 0             # minimum value of X3

--- a/inputs/tov_cart.pin
+++ b/inputs/tov_cart.pin
@@ -14,6 +14,8 @@
 
 <phoebus>
 problem = tov
+ix1_bc = outflow
+ox1_bc = outflow
 
 <parthenon/job>
 problem_id  = tov # problem ID: basename of output filenames
@@ -39,11 +41,15 @@ variables = p.density,  &
 	    src_terms
 
 file_type   = hdf5      # Tabular data dump
-dt          = 1         # time increment between outputs
+dt          = 100       # time increment between outputs
+
+<parthenon/output2>
+file_type = hst
+dt = 10
 
 <parthenon/time>
 nlim        = -1        # cycle limit
-tlim        = 1000      # time limit
+tlim        = 2000      # time limit
 integrator  = rk2       # time integration algorithm
 ncycle_out  = 1         # interval for stdout summary info
 dt_init_fact = 1.e-6
@@ -53,19 +59,19 @@ nghost = 4
 #refinement = adaptive
 #numlevel = 3
 
-nx1         = 250         # Number of zones in X1-direction
+nx1         = 200         # Number of zones in X1-direction
 x1min       = -100        # minimum value of X1
 x1max       = 100         # maximum value of X1
 ix1_bc      = periodic    # Inner-X1 boundary condition flag
 ox1_bc      = periodic    # Outer-X1 boundary condition flag
 
-nx2         = 250           # Number of zones in X2-direction
+nx2         = 200           # Number of zones in X2-direction
 x2min       = -100          # minimum value of X2
 x2max       = 100           # maximum value of X2. Pi
 ix2_bc      = periodic      # Inner-X2 boundary condition flag
 ox2_bc      = periodic      # Outer-X2 boundary condition flag
 
-nx3         = 250           # Number of zones in X3-direction
+nx3         = 200           # Number of zones in X3-direction
 x3min       = -100          # minimum value of X3
 x3max       = 100           # maximum value of X3. 2*pi
 ix3_bc      = periodic      # Inner-X3 boundary condition flag
@@ -74,9 +80,9 @@ ox3_bc      = periodic      # Outer-X3 boundary condition flfgag
 num_threads = 1         # maximum number of OMP threads
 
 <parthenon/meshblock>
-nx1 = 64
-nx2 = 64
-nx3 = 64
+nx1 = 200
+nx2 = 200
+nx3 = 200
 
 <parthenon/refinement0>
 field = c.c.bulk.rho
@@ -102,28 +108,28 @@ recon = weno5
 c2p_max_iter = 1000
 Ye = false
 
-# Fixups aren't necessary for this problem,
-# especially with the Cowling approximation
-# and reflecting outer boundary.
-# But they also don't do any harm.
 <fixup>
 enable_floors = true
 enable_ceilings = true
-enable_flux_fixup = false
+enable_flux_fixup = true
 enable_c2p_fixup = true
-floor_type = ConstantRhoSie
-rho0_floor = 1.0e-9
-sie0_floor = 1.0e-9
+floor_type = X1RhoSie
+rho0_floor = 1.0e-8
+sie0_floor = 1.0e-3
 rho_exp_floor = -2.0
 sie_exp_floor = -1.0
 ceiling_type = ConstantGamSie
 sie0_ceiling = 10.0;
 gam0_ceiling = 10.0;
 
+<geometry>
+do_fd_on_grid = true
+finite_differences_dx = 1e-8
+
 <monopole_gr>
 enabled = true
-npoints = 1024
-rout = 100
+npoints = 2048
+rout = 250
 # Disables time derivatives. Runs only at initialization
 force_static = true
 # Runs the first n subcycles. Then freezes. Source terms are not disabled.

--- a/inputs/tov_cart.pin
+++ b/inputs/tov_cart.pin
@@ -1,0 +1,153 @@
+# © 2021. Triad National Security, LLC. All rights reserved.  This
+# program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad
+# National Security, LLC for the U.S.  Department of Energy/National
+# Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is
+# granted for itself and others acting on its behalf a nonexclusive,
+# paid-up, irrevocable worldwide license in this material to reproduce,
+# prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+
+# Tohlmann-Oppenheimer-Volkov star in hydrostatic equilibrium
+
+<phoebus>
+problem = tov
+
+<parthenon/job>
+problem_id  = tov # problem ID: basename of output filenames
+
+<parthenon/output1>
+variables = p.density,  &
+      	    c.density,  &
+            p.velocity, &
+            c.momentum, &
+            p.energy,   &
+            c.energy,   &
+	    pressure,	&
+      	    cs, &
+      	    p.ye, &
+      	    g.c.coord, &
+     	    g.n.coord, &
+	    g.c.alpha, &
+	    g.c.detgam, &
+	    g.c.gcov, &
+	    g.c.dg, &
+	    g.c.dalpha, &
+	    flux_divergence, &
+	    src_terms
+
+file_type   = hdf5      # Tabular data dump
+dt          = 1         # time increment between outputs
+
+<parthenon/time>
+nlim        = -1        # cycle limit
+tlim        = 1000      # time limit
+integrator  = rk2       # time integration algorithm
+ncycle_out  = 1         # interval for stdout summary info
+dt_init_fact = 1.e-6
+
+<parthenon/mesh>
+nghost = 4
+#refinement = adaptive
+#numlevel = 3
+
+nx1         = 250         # Number of zones in X1-direction
+x1min       = -100        # minimum value of X1
+x1max       = 100         # maximum value of X1
+ix1_bc      = periodic    # Inner-X1 boundary condition flag
+ox1_bc      = periodic    # Outer-X1 boundary condition flag
+
+nx2         = 250           # Number of zones in X2-direction
+x2min       = -100          # minimum value of X2
+x2max       = 100           # maximum value of X2. Pi
+ix2_bc      = periodic      # Inner-X2 boundary condition flag
+ox2_bc      = periodic      # Outer-X2 boundary condition flag
+
+nx3         = 250           # Number of zones in X3-direction
+x3min       = -100          # minimum value of X3
+x3max       = 100           # maximum value of X3. 2*pi
+ix3_bc      = periodic      # Inner-X3 boundary condition flag
+ox3_bc      = periodic      # Outer-X3 boundary condition flfgag
+
+num_threads = 1         # maximum number of OMP threads
+
+<parthenon/meshblock>
+nx1 = 64
+nx2 = 64
+nx3 = 64
+
+<parthenon/refinement0>
+field = c.c.bulk.rho
+method = derivative_order_1
+max_level = 3
+
+<eos>
+type = IdealGas
+Gamma = 2
+Cv = 1.0
+
+<physics>
+hydro = true
+he = false
+3t = false
+rad = false
+
+<fluid>
+xorder = 2
+cfl = 0.25
+riemann = llf
+recon = weno5
+c2p_max_iter = 1000
+Ye = false
+
+# Fixups aren't necessary for this problem,
+# especially with the Cowling approximation
+# and reflecting outer boundary.
+# But they also don't do any harm.
+<fixup>
+enable_floors = true
+enable_ceilings = true
+enable_flux_fixup = false
+enable_c2p_fixup = true
+floor_type = ConstantRhoSie
+rho0_floor = 1.0e-9
+sie0_floor = 1.0e-9
+rho_exp_floor = -2.0
+sie_exp_floor = -1.0
+ceiling_type = ConstantGamSie
+sie0_ceiling = 10.0;
+gam0_ceiling = 10.0;
+
+<monopole_gr>
+enabled = true
+npoints = 1024
+rout = 100
+# Disables time derivatives. Runs only at initialization
+force_static = true
+# Runs the first n subcycles. Then freezes. Source terms are not disabled.
+# -1 means it's always run.
+run_n_times = -1
+# dtfac is for time step control. 0 < dtfac <= 1.
+# time step will be <= dtfac*(time rate of change of lapse)
+dtfac = 0.9
+# warn_on_dt tries to estimate if first-order operator split is sufficiently accurate.
+# Compares (dalpha/dt) computed analytically with numerical difference
+# between two subcycles. Warns if difference is larger than dtwarn_eps
+warn_on_dt = false
+dtwarn_eps = 1e-5
+
+<tov>
+enabled = true
+Pc = 1e-6
+entropy = 8
+# pressure below which we terminate the TOV solver and transition to atmosphere
+Pmin = 1e-12 
+# The atmosphere values in the problem generator for density and energy
+rhomin = 1e-12
+epsmin = 1e-12
+# Velocity perturbation
+vpert_amp = 0
+vpert_radius = 5
+vpert_sigma = 1

--- a/inputs/tov_cart.pin
+++ b/inputs/tov_cart.pin
@@ -16,6 +16,11 @@
 problem = tov
 ix1_bc = outflow
 ox1_bc = outflow
+ix2_bc = outflow
+ox2_bc = outflow
+ix3_bc = outflow
+ox3_bc = outflow
+
 
 <parthenon/job>
 problem_id  = tov # problem ID: basename of output filenames
@@ -62,20 +67,20 @@ nghost = 4
 nx1         = 200         # Number of zones in X1-direction
 x1min       = -100        # minimum value of X1
 x1max       = 100         # maximum value of X1
-ix1_bc      = periodic    # Inner-X1 boundary condition flag
-ox1_bc      = periodic    # Outer-X1 boundary condition flag
+ix1_bc      = user        # Inner-X1 boundary condition flag
+ox1_bc      = user        # Outer-X1 boundary condition flag
 
 nx2         = 200           # Number of zones in X2-direction
 x2min       = -100          # minimum value of X2
 x2max       = 100           # maximum value of X2. Pi
-ix2_bc      = periodic      # Inner-X2 boundary condition flag
-ox2_bc      = periodic      # Outer-X2 boundary condition flag
+ix2_bc      = user          # Inner-X2 boundary condition flag
+ox2_bc      = user          # Outer-X2 boundary condition flag
 
 nx3         = 200           # Number of zones in X3-direction
 x3min       = -100          # minimum value of X3
 x3max       = 100           # maximum value of X3. 2*pi
-ix3_bc      = periodic      # Inner-X3 boundary condition flag
-ox3_bc      = periodic      # Outer-X3 boundary condition flfgag
+ix3_bc      = user          # Inner-X3 boundary condition flag
+ox3_bc      = user          # Outer-X3 boundary condition flfgag
 
 num_threads = 1         # maximum number of OMP threads
 
@@ -113,7 +118,7 @@ enable_floors = true
 enable_ceilings = true
 enable_flux_fixup = true
 enable_c2p_fixup = true
-floor_type = X1RhoSie
+floor_type = RRhoSie
 rho0_floor = 1.0e-8
 sie0_floor = 1.0e-3
 rho_exp_floor = -2.0

--- a/inputs/tov_cart.pin
+++ b/inputs/tov_cart.pin
@@ -14,10 +14,17 @@
 
 <phoebus>
 problem = tov
+
+# To use Octant symmetry
+# change inner BCs to reflect
+# and change domain to [0,xmax]
+
 ix1_bc = outflow
 ox1_bc = outflow
+
 ix2_bc = outflow
 ox2_bc = outflow
+
 ix3_bc = outflow
 ox3_bc = outflow
 
@@ -40,13 +47,15 @@ variables = p.density,  &
 	    g.c.alpha, &
 	    g.c.detgam, &
 	    g.c.gcov, &
+            g.c.gamcon, &
+            g.c.bcon, &
 	    g.c.dg, &
 	    g.c.dalpha, &
 	    flux_divergence, &
 	    src_terms
 
 file_type   = hdf5      # Tabular data dump
-dt          = 100       # time increment between outputs
+dt          = 200       # time increment between outputs
 
 <parthenon/output2>
 file_type = hst
@@ -84,10 +93,10 @@ ox3_bc      = user          # Outer-X3 boundary condition flfgag
 
 num_threads = 1         # maximum number of OMP threads
 
-<parthenon/meshblock>
-nx1 = 200
-nx2 = 200
-nx3 = 200
+# <parthenon/meshblock>
+# nx1 = 200
+# nx2 = 200
+# nx3 = 200
 
 <parthenon/refinement0>
 field = c.c.bulk.rho
@@ -109,7 +118,7 @@ rad = false
 xorder = 2
 cfl = 0.25
 riemann = llf
-recon = weno5
+recon = linear
 c2p_max_iter = 1000
 Ye = false
 
@@ -119,7 +128,7 @@ enable_ceilings = true
 enable_flux_fixup = true
 enable_c2p_fixup = true
 floor_type = RRhoSie
-rho0_floor = 1.0e-8
+rho0_floor = 1.0e-6
 sie0_floor = 1.0e-3
 rho_exp_floor = -2.0
 sie_exp_floor = -1.0
@@ -136,7 +145,7 @@ enabled = true
 npoints = 2048
 rout = 250
 # Disables time derivatives. Runs only at initialization
-force_static = true
+force_static = false
 # Runs the first n subcycles. Then freezes. Source terms are not disabled.
 # -1 means it's always run.
 run_n_times = -1
@@ -154,7 +163,7 @@ enabled = true
 Pc = 1e-6
 entropy = 8
 # pressure below which we terminate the TOV solver and transition to atmosphere
-Pmin = 1e-12 
+Pmin = 1e-8
 # The atmosphere values in the problem generator for density and energy
 rhomin = 1e-12
 epsmin = 1e-12

--- a/scripts/python/movie2d.py
+++ b/scripts/python/movie2d.py
@@ -62,7 +62,7 @@ parser.add_argument('-s','--savename', type=str,
                     help='Name to save movie as')
 parser.add_argument('-l','--linear',action='store_true',
                     help='Use linear, instead of log scale')
-parser.add_arrgument('--noclean',action='store_true',
+parser.add_argument('--noclean',action='store_true',
                      help="Don't clean up the temporary directory when done")
 parser.add_argument('varname', type=str, help='Variable to plot')
 parser.add_argument('files', type=str, nargs='+',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(phoebus
   geometry/geometry.hpp
   geometry/geometry_defaults.hpp
   geometry/geometry_utils.hpp
+  geometry/sph2cart.cpp
+  geometry/sph2cart.hpp
   geometry/tetrads.hpp
 
   geometry/inchworm.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ add_executable(phoebus
   phoebus_utils/cell_locations.hpp
   phoebus_utils/unit_conversions.cpp
   phoebus_utils/unit_conversions.hpp
+  phoebus_utils/history.hpp
   phoebus_utils/linear_algebra.hpp
   phoebus_utils/phoebus_interpolation.hpp
   phoebus_utils/reduction.hpp

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -80,13 +80,13 @@ class Floors {
       rflr = scratch;
     } break;
     case FloorFlag::X1RhoSie:
-      rflr = r0_ * std::pow(x1, ralpha_);
-      sflr = s0_ * std::pow(x1, salpha_);
+      rflr = r0_ * std::min(1.0, std::pow(x1, ralpha_));
+      sflr = s0_ * std::min(1.0, std::pow(x1, salpha_));
       break;
     case FloorFlag::RRhoSie: {
       Real r = std::sqrt(x1 * x1 + x2 * x2 + x3 * x3);
-      rflr = r0_ * std::pow(r, ralpha_);
-      sflr = s0_ * std::pow(r, salpha_);
+      rflr = r0_ * std::min(1.0, std::pow(r, ralpha_));
+      sflr = s0_ * std::min(1.0, std::pow(r, salpha_));
     } break;
     default:
       PARTHENON_FAIL("No valid floor set.");

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -493,15 +493,15 @@ void InitializeCachedCoordinateSystem(ParameterInput *pin, StateDescriptor *geom
   // in their params during initialization.
   // If it's available it will be read out and returned here.
   // Otherwise it is set to false.
-  bool time_dependent = params.Get("time_dependent", false);
+  const bool time_dependent = params.Get("time_dependent", false);
   const int nvar_deriv = time_dependent ? NDFULL : NDSPACE;
 
-  bool axisymmetric = pin->GetOrAddBoolean("geometry", "axisymmetric", false);
+  const bool axisymmetric = pin->GetOrAddBoolean("geometry", "axisymmetric", false);
   params.Add("axisymmetric", axisymmetric);
 
   // This tells the goemetry infrastructure not to call
   // SetGeometryDefault, because the cached geometry will handle it.
-  bool do_defaults = false;
+  const bool do_defaults = false;
   params.Add("do_defaults", do_defaults);
 
   // Optionally use finite differences on the grid to set the metric

--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -504,7 +504,7 @@ void InitializeCachedCoordinateSystem(ParameterInput *pin, StateDescriptor *geom
   bool do_fd_on_grid_pin = pin->GetOrAddBoolean("geometry", "do_fd_on_grid", false);
   if (params.hasKey("do_fd_on_grid")) {
     do_fd_on_grid = params.Get<bool>("do_fd_on_grid");
-    if (parthenon::Globals::my_rank == 0) {
+    if ((do_fd_on_grid != do_fd_on_grid_pin) && parthenon::Globals::my_rank == 0) {
       std::stringstream ss;
       ss << "do_fd_on_grid set by input deck as " << do_fd_on_grid_pin
          << " but set by the geometry class to be " << do_fd_on_grid

--- a/src/geometry/modified_system.hpp
+++ b/src/geometry/modified_system.hpp
@@ -48,7 +48,7 @@ namespace Geometry {
 // transformation is time-dependent. It means the metric is.
 // TODO(JMM): A time-dependent version of this may be worth pursuing
 // eventually.
-template <typename System, typename Transformation, bool TIME_DEPENDENT=false>
+template <typename System, typename Transformation, bool TIME_DEPENDENT = false>
 class Modified {
  public:
   Modified() = default;
@@ -58,8 +58,7 @@ class Modified {
         s_(std::forward<Args>(args)...) {}
   template <typename... Args>
   Modified(const Real dx, const Transformation &GetTransformation, Args... args)
-      : dx_(dx), GetTransformation_(GetTransformation),
-        s_(std::forward<Args>(args)...) {}
+      : dx_(dx), GetTransformation_(GetTransformation), s_(std::forward<Args>(args)...) {}
 
   KOKKOS_INLINE_FUNCTION
   Real Lapse(Real X0, Real X1, Real X2, Real X3) const {

--- a/src/geometry/modified_system.hpp
+++ b/src/geometry/modified_system.hpp
@@ -44,24 +44,21 @@ namespace Geometry {
 //                 Real Jcov[NDSPACE][NDSPACE],
 //                 Real Jcon[NDSPACE][NDSPACE]) const;
 //
+// The TIME_DEPENDENT template parameter DOES NOT mean the
+// transformation is time-dependent. It means the metric is.
 // TODO(JMM): A time-dependent version of this may be worth pursuing
 // eventually.
-template <typename System, typename Transformation>
+template <typename System, typename Transformation, bool TIME_DEPENDENT=false>
 class Modified {
  public:
   Modified() = default;
   template <typename... Args>
   Modified(const Transformation &GetTransformation, Args... args)
-      : time_dependent_(false), dx_(1e-10), GetTransformation_(GetTransformation),
+      : dx_(1e-10), GetTransformation_(GetTransformation),
         s_(std::forward<Args>(args)...) {}
   template <typename... Args>
   Modified(const Real dx, const Transformation &GetTransformation, Args... args)
-      : time_dependent_(false), dx_(dx), GetTransformation_(GetTransformation),
-        s_(std::forward<Args>(args)...) {}
-  template <typename... Args>
-  Modified(const bool time_dependent, const Real dx,
-           const Transformation &GetTransformation, Args... args)
-      : time_dependent_(time_dependent), dx_(dx), GetTransformation_(GetTransformation),
+      : dx_(dx), GetTransformation_(GetTransformation),
         s_(std::forward<Args>(args)...) {}
 
   KOKKOS_INLINE_FUNCTION
@@ -196,7 +193,7 @@ class Modified {
     // If time-dependent, assume coordinate transformation is time
     // indepedent, pull dg_{mu nu}/dt from underlying system, and
     // transform mu and nu
-    if (time_dependent_) {
+    if (TIME_DEPENDENT) {
       Real dg0[NDFULL][NDFULL][NDFULL];
       Real C[NDSPACE];
       Real Jcon[NDSPACE][NDSPACE];
@@ -216,7 +213,7 @@ class Modified {
     Utils::SetGradLnAlphaByFD(*this, dx_, X0, X1, X2, X3, da);
     // If time-dependent, assume coordinate transformation is time
     // indepedent, pull dalpha/dt from underlying system
-    if (time_dependent_) {
+    if (TIME_DEPENDENT) {
       Real da0[NDFULL];
       Real C[NDSPACE];
       Real Jcon[NDSPACE][NDSPACE];
@@ -248,10 +245,6 @@ class Modified {
   Real dx_ = 1e-10;                  // finite differences dx
   System s_;                         // underlying coordinate system
   Transformation GetTransformation_; // transformation operator
-
-  // This doesn't mean the transformation is time-dependent. It means
-  // the metric is.
-  bool time_dependent_ = false;
 };
 
 } // namespace Geometry

--- a/src/geometry/modified_system.hpp
+++ b/src/geometry/modified_system.hpp
@@ -179,7 +179,7 @@ class Modified {
     Real C[NDSPACE];
     Real Jcov[NDSPACE][NDSPACE];
     Real Jcon[NDSPACE][NDSPACE];
-    GetTransformation_(X1, X2, XI can 3, C, Jcov, Jcon);
+    GetTransformation_(X1, X2, X3, C, Jcov, Jcon);
     Real detJ = LinearAlgebra::Determinant(Jcov);
     return s_.DetG(X0, C[0], C[1], C[2]) * std::abs(detJ);
   }
@@ -245,8 +245,8 @@ class Modified {
       return A[mu - 1][nu - 1];
     }
   }
-  Real dx_ = 1e-10; // finite differences dx
-  System s_; // underlying coordinate system
+  Real dx_ = 1e-10;                  // finite differences dx
+  System s_;                         // underlying coordinate system
   Transformation GetTransformation_; // transformation operator
 
   // This doesn't mean the transformation is time-dependent. It means

--- a/src/geometry/modified_system.hpp
+++ b/src/geometry/modified_system.hpp
@@ -169,7 +169,7 @@ class Modified {
     Real Jcon[NDSPACE][NDSPACE];
     GetTransformation_(X1, X2, X3, C, Jcov, Jcon);
     Real detJ = LinearAlgebra::Determinant(Jcov);
-    return std::abs(s_.DetGamma(X0, C[0], C[1], C[2])*detJ);
+    return std::abs(s_.DetGamma(X0, C[0], C[1], C[2]) * detJ);
   }
   KOKKOS_INLINE_FUNCTION
   Real DetG(Real X0, Real X1, Real X2, Real X3) const {

--- a/src/geometry/modified_system.hpp
+++ b/src/geometry/modified_system.hpp
@@ -26,6 +26,7 @@ using namespace parthenon::package::prelude;
 // phoebus includes
 #include "geometry/geometry_utils.hpp"
 #include "phoebus_utils/linear_algebra.hpp"
+#include "phoebus_utils/robust.hpp"
 
 namespace Geometry {
 
@@ -168,7 +169,7 @@ class Modified {
     Real Jcon[NDSPACE][NDSPACE];
     GetTransformation_(X1, X2, X3, C, Jcov, Jcon);
     Real detJ = LinearAlgebra::Determinant(Jcov);
-    return s_.DetGamma(X0, C[0], C[1], C[2]) * std::abs(detJ);
+    return std::abs(s_.DetGamma(X0, C[0], C[1], C[2])*detJ);
   }
   KOKKOS_INLINE_FUNCTION
   Real DetG(Real X0, Real X1, Real X2, Real X3) const {
@@ -177,7 +178,7 @@ class Modified {
     Real Jcon[NDSPACE][NDSPACE];
     GetTransformation_(X1, X2, X3, C, Jcov, Jcon);
     Real detJ = LinearAlgebra::Determinant(Jcov);
-    return s_.DetG(X0, C[0], C[1], C[2]) * std::abs(detJ);
+    return std::abs(s_.DetG(X0, C[0], C[1], C[2]) * detJ);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/src/geometry/monopole.cpp
+++ b/src/geometry/monopole.cpp
@@ -110,11 +110,10 @@ MplCartMeshBlock GetCoordinateSystem<MplCartMeshBlock>(MeshBlockData<Real> *rc) 
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
 
-  bool time_dependent = true;
   Real dxfd = pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-  return MplCartMeshBlock(indexer, time_dependent, dxfd, transformation, hypersurface,
+  return MplCartMeshBlock(indexer, dxfd, transformation, hypersurface,
                           alpha, beta, gradients, rgrid);
 }
 template <>
@@ -131,11 +130,10 @@ MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
 
-  bool time_dependent = true;
   Real dxfd = pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-  return MplCartMesh(indexer, time_dependent, dxfd, transformation, hypersurface, alpha,
+  return MplCartMesh(indexer, dxfd, transformation, hypersurface, alpha,
                      beta, gradients, rgrid);
 }
 

--- a/src/geometry/monopole.cpp
+++ b/src/geometry/monopole.cpp
@@ -113,8 +113,8 @@ MplCartMeshBlock GetCoordinateSystem<MplCartMeshBlock>(MeshBlockData<Real> *rc) 
   Real dxfd = pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-  return MplCartMeshBlock(indexer, dxfd, transformation, hypersurface,
-                          alpha, beta, gradients, rgrid);
+  return MplCartMeshBlock(indexer, dxfd, transformation, hypersurface, alpha, beta,
+                          gradients, rgrid);
 }
 template <>
 MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
@@ -133,8 +133,8 @@ MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
   Real dxfd = pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-  return MplCartMesh(indexer, dxfd, transformation, hypersurface, alpha,
-                     beta, gradients, rgrid);
+  return MplCartMesh(indexer, dxfd, transformation, hypersurface, alpha, beta, gradients,
+                     rgrid);
 }
 
 template <>

--- a/src/geometry/monopole.cpp
+++ b/src/geometry/monopole.cpp
@@ -46,6 +46,11 @@ void Initialize<MplCartMeshBlock>(ParameterInput *pin, StateDescriptor *geometry
   const bool do_fd_on_grid = true;
   params.Add("time_dependent", time_dependent);
   params.Add("do_fd_on_grid", do_fd_on_grid);
+  Real dxfd_geom = pin->GetOrAddReal("geometry", "finite_differences_dx", 1e-8);
+  Real dxfd = pin->GetOrAddReal("coordinates", "finite_differences_dx", dxfd_geom);
+  if (!params.hasKey("dxfd")) {
+    params.Add("dxfd", dxfd);
+  }
   return;
 }
 
@@ -104,9 +109,13 @@ MplCartMeshBlock GetCoordinateSystem<MplCartMeshBlock>(MeshBlockData<Real> *rc) 
   auto gradients = params.Get<MonopoleGR::Gradients_t>("gradients");
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
+
+  bool time_dependent = true;
+  Real dxfd = pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-  return MplCartMeshBlock(indexer, transformation, hypersurface, alpha, beta, gradients, rgrid);
+  return MplCartMeshBlock(indexer, time_dependent, dxfd, transformation, hypersurface,
+                          alpha, beta, gradients, rgrid);
 }
 template <>
 MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
@@ -121,9 +130,13 @@ MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
   auto gradients = params.Get<MonopoleGR::Gradients_t>("gradients");
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
+
+  bool time_dependent = true;
+  Real dxfd = pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-  return MplCartMesh(indexer, transformation, hypersurface, alpha, beta, gradients, rgrid);
+  return MplCartMesh(indexer, time_dependent, dxfd, transformation, hypersurface, alpha,
+                     beta, gradients, rgrid);
 }
 
 template <>

--- a/src/geometry/monopole.cpp
+++ b/src/geometry/monopole.cpp
@@ -110,7 +110,8 @@ MplCartMeshBlock GetCoordinateSystem<MplCartMeshBlock>(MeshBlockData<Real> *rc) 
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
 
-  Real dxfd = pkg->Param<Real>("dxfd");
+  auto &geom_pkg = rc->GetParentPointer()->packages.Get("geometry");
+  Real dxfd = geom_pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
   return MplCartMeshBlock(indexer, dxfd, transformation, hypersurface, alpha, beta,
@@ -130,7 +131,8 @@ MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
 
-  Real dxfd = pkg->Param<Real>("dxfd");
+  auto &geom_pkg = rc->GetParentPointer()->packages.Get("geometry");
+  Real dxfd = geom_pkg->Param<Real>("dxfd");
   auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
   return MplCartMesh(indexer, dxfd, transformation, hypersurface, alpha, beta, gradients,

--- a/src/geometry/monopole.cpp
+++ b/src/geometry/monopole.cpp
@@ -35,18 +35,22 @@ namespace Geometry {
 template <>
 void Initialize<MplSphMeshBlock>(ParameterInput *pin, StateDescriptor *geometry) {
   Params &params = geometry->AllParams();
-  bool time_dependent = true;
+  const bool time_dependent = true;
   params.Add("time_dependent", time_dependent);
   return;
 }
 template <>
 void Initialize<MplCartMeshBlock>(ParameterInput *pin, StateDescriptor *geometry) {
   Params &params = geometry->AllParams();
-  bool time_dependent = true;
+  const bool time_dependent = true;
+  const bool do_fd_on_grid = true;
   params.Add("time_dependent", time_dependent);
+  params.Add("do_fd_on_grid", do_fd_on_grid);
   return;
 }
-// TODO(JMM): Might need to figure this out more carefully
+
+// The geometry on a block is set by the monopole solver or by the
+// Cached machinery
 template <>
 void SetGeometry<MplSphMeshBlock>(MeshBlockData<Real> *rc) {}
 template <>
@@ -100,7 +104,9 @@ MplCartMeshBlock GetCoordinateSystem<MplCartMeshBlock>(MeshBlockData<Real> *rc) 
   auto gradients = params.Get<MonopoleGR::Gradients_t>("gradients");
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
-  return MplCartMeshBlock(indexer, hypersurface, alpha, beta, gradients, rgrid);
+  auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
+
+  return MplCartMeshBlock(indexer, transformation, hypersurface, alpha, beta, gradients, rgrid);
 }
 template <>
 MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
@@ -115,10 +121,10 @@ MplCartMesh GetCoordinateSystem<MplCartMesh>(MeshData<Real> *rc) {
   auto gradients = params.Get<MonopoleGR::Gradients_t>("gradients");
   auto rgrid = params.Get<MonopoleGR::Radius>("radius");
   auto indexer = GetIndexer(rc);
-  return MplCartMesh(indexer, hypersurface, alpha, beta, gradients, rgrid);
-}
+  auto transformation = GetTransformation<SphericalToCartesian>(pkg.get());
 
-// TODO(JMM): These cached coordinate system calls may need to be revisited.
+  return MplCartMesh(indexer, transformation, hypersurface, alpha, beta, gradients, rgrid);
+}
 
 template <>
 void Initialize<CMplSphMeshBlock>(ParameterInput *pin, StateDescriptor *geometry) {

--- a/src/geometry/monopole.hpp
+++ b/src/geometry/monopole.hpp
@@ -44,7 +44,6 @@ namespace Geometry {
  */
 class MonopoleSph {
  public:
-
   MonopoleSph() = default;
   KOKKOS_INLINE_FUNCTION
   MonopoleSph(const MonopoleGR::Hypersurface_t &hypersurface,
@@ -245,7 +244,7 @@ void Initialize<CMplSphMeshBlock>(ParameterInput *pin, StateDescriptor *geometry
 
 // --------------------------------------------------------------------------------
 
-/* 
+/*
  * Cartesian Monopole class.
  * Built explicitly on modifiers and the cached coordinate system.  We
  * define the types for non-cached MonopoleCart, to make all the other

--- a/src/geometry/monopole.hpp
+++ b/src/geometry/monopole.hpp
@@ -246,11 +246,9 @@ void Initialize<CMplSphMeshBlock>(ParameterInput *pin, StateDescriptor *geometry
 
 /*
  * Cartesian Monopole class.
- * Built explicitly on modifiers and the cached coordinate system.  We
- * define the types for non-cached MonopoleCart, to make all the other
- * machinery work, but we forbid this in the cmake.
+ * Built explicitly on modifiers.
  */
-using MonopoleCart = Modified<MonopoleSph, SphericalToCartesian>;
+using MonopoleCart = Modified<MonopoleSph, SphericalToCartesian, true>;
 
 using MplCartMeshBlock = Analytic<MonopoleCart, IndexerMeshBlock>;
 using CMplCartMeshBlock = CachedOverMeshBlock<Analytic<MonopoleCart, IndexerMeshBlock>>;

--- a/src/geometry/sph2cart.cpp
+++ b/src/geometry/sph2cart.cpp
@@ -1,0 +1,37 @@
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#include <array>
+#include <cmath>
+
+// Parthenon includes
+#include <kokkos_abstraction.hpp>
+#include <parthenon/package.hpp>
+#include <utils/error_checking.hpp>
+using namespace parthenon::package::prelude;
+
+// phoebus includes
+#include "geometry/geometry_defaults.hpp"
+#include "geometry/geometry_utils.hpp"
+#include "phoebus_utils/linear_algebra.hpp"
+
+#include "geometry/sph2cart.hpp"
+
+namespace Geometry {
+
+template <>
+SphericalToCartesian GetTransformation<SphericalToCartesian>(StateDescriptor *pkg) {
+  return SphericalToCartesian();
+}
+
+} // namespace Geometry

--- a/src/geometry/sph2cart.hpp
+++ b/src/geometry/sph2cart.hpp
@@ -83,13 +83,13 @@ class SphericalToCartesian {
     // better-behaved because these quantities cancel out with the
     // quantities in the metric.
     Jcov[0][0] = sth * cph;
-    Jcov[0][1] = sth *sph;
+    Jcov[0][1] = sth * sph;
     Jcov[0][2] = cth;
     Jcov[1][0] = ratio(cth * cph, r);
     Jcov[1][1] = ratio(cth * sph, r);
     Jcov[1][2] = -ratio(sth, r);
-    Jcov[2][0] = -ratio(sph, r*sth);
-    Jcov[2][1] = ratio(cph, r*sth);
+    Jcov[2][0] = -ratio(sph, r * sth);
+    Jcov[2][1] = ratio(cph, r * sth);
     Jcov[2][2] = 0;
 
     // Jcon

--- a/src/geometry/sph2cart.hpp
+++ b/src/geometry/sph2cart.hpp
@@ -68,6 +68,7 @@ class SphericalToCartesian {
     // Jcov has x^{mu'} = {r,th,ph}
 
     // Jcov
+    /*
     Jcov[0][0] = ratio(x, r);             // dr/dx
     Jcov[0][1] = ratio(y, r);             // dr/dy
     Jcov[0][2] = ratio(z, r);             // dr/dz
@@ -77,6 +78,19 @@ class SphericalToCartesian {
     Jcov[2][0] = -ratio(y, rho2);         // dph/dx
     Jcov[2][1] = ratio(x, rho2);          // dph/dy
     Jcov[2][2] = 0;                       // dph/dz
+    */
+    // JMM: The version with all spherical quantities is substantially
+    // better-behaved because these quantities cancel out with the
+    // quantities in the metric.
+    Jcov[0][0] = sth * cph;
+    Jcov[0][1] = sth *sph;
+    Jcov[0][2] = cth;
+    Jcov[1][0] = ratio(cth * cph, r);
+    Jcov[1][1] = ratio(cth * sph, r);
+    Jcov[1][2] = -ratio(sth, r);
+    Jcov[2][0] = -ratio(sph, r*sth);
+    Jcov[2][1] = ratio(cph, r*sth);
+    Jcov[2][2] = 0;
 
     // Jcon
     Jcon[0][0] = sth * cph;      // dx/dr
@@ -95,9 +109,9 @@ class SphericalToCartesian {
                                    Real &th, Real &ph, Real &r2, Real &sth, Real &cth,
                                    Real &sph, Real &cph) const {
     using robust::ratio;
-    r2 = x * x + y * y + z * z;
+    r2 = robust::make_positive(x * x + y * y + z * z);
     r = std::sqrt(r2);
-    th = std::acos(ratio(z, r));
+    th = robust::make_positive(std::acos(ratio(z, r)));
     ph = std::atan2(y, x);
     sth = std::sin(th);
     cth = std::cos(th);

--- a/src/geometry/sph2cart.hpp
+++ b/src/geometry/sph2cart.hpp
@@ -1,0 +1,99 @@
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#ifndef GEOMETRY_SPH2CART_HPP_
+#define GEOMETRY_SPH2CART_HPP_
+
+#include <array>
+#include <cmath>
+
+// Parthenon includes
+#include <kokkos_abstraction.hpp>
+#include <parthenon/package.hpp>
+#include <utils/error_checking.hpp>
+using namespace parthenon::package::prelude;
+
+// phoebus includes
+#include "geometry/geometry_defaults.hpp"
+#include "geometry/geometry_utils.hpp"
+#include "phoebus_utils/linear_algebra.hpp"
+#include "phoebus_utils/robust.hpp"
+
+namespace Geometry {
+
+// Maps a geometry in spherical coordinates to one in Cartesian
+// coordinates in the standard way:
+// x = r sin(theta) cos(phi)
+// y = r sin(theta) sin(phi)
+// z = r cos(theta)
+// Since this object maps the GEOMETRY object from sph to cart, it actually
+// maps the coordinates themselves the otehr way: cart -> sph:
+// r = sqrt(x**2 + y**2 + z**2)
+// th = acos(z/r)
+// ph = atan(y / x)
+class SphericalToCartesian {
+public:
+  SphericalToCartesian() = default;
+  KOKKOS_INLINE_FUNCTION
+  void operator()(Real X1, Real X2, Real X3, Real C[NDSPACE], Real Jcov[NDSPACE][NDSPACE],
+                  Real Jcon[NDSPACE][NDSPACE]) const {
+    using robust::ratio;
+    const Real x  = X1;
+    const Real y  = X2;
+    const Real z  = X3;
+    const Real r2 = x*x + y*y + z*z;
+    const Real r  = std::sqrt(r2);
+    const Real th = std::acos(ratio(z, r));
+    const Real ph = std::atan2(y, x);
+    C[0] = r;
+    C[1] = th;
+    C[2] = ph;
+
+    const Real rho2 = x*x + y * y;
+    const Real rho = std::sqrt(rho2);
+
+    // These are dx^{mu'}/dx^{mu}
+    // convention is mu' is first index, mu is second
+    // Jcon has x^{mu'} = {x,y,z}
+    // Jcov has x^{mu'} = {r,th,ph}
+
+    // Jcov
+    Jcov[0][0] = ratio(x, r); // dr/dx
+    Jcov[0][1] = ratio(y, r); // dr/dy
+    Jcov[0][2] = ratio(z, r); // dr/dz
+    Jcov[1][0] = robust::ratio(x * z, r2 * rho); // dth/dx
+    Jcov[1][1] = robust::ratio(y * z, r2 * rho2); // dth/dy
+    Jcov[1][2] = -robust::ratio(rho, r2); // dth/dz
+    Jcov[2][0] = -robust::ratio(y, rho2); // dph/dx
+    Jcov[2][1] = robust::ratio(x, rho2);  // dph/dy
+    Jcov[2][2] = 0; // dph/dz
+
+    // Jcon
+    Jcon[0][0] = sth * cph; // dx/dr
+    Jcon[0][1] = r * cth * cph; // dx/dth
+    Jcon[0][2] = -r * sth * sph; // dx/dph
+    Jcon[1][0] = sth * sph; // dy/dr
+    Jcon[1][1] = r * cth * sph; // dy/dth
+    Jcon[1][2] = r * sth * cph; // dy/dph
+    Jcon[2][0] = cth; // dz/dr
+    Jcon[2][1] = -r * sth; // dz/dth
+    Jcon[2][2] = 0; // dz/dph
+  }
+};
+
+template <>
+SphericalToCartesian GetTransformation<SphericalToCartesian>(StateDescriptor *pkg);
+
+} // namespace Geometry
+
+#endif // GEOMETRY_SPH2CART_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,8 +29,6 @@
 #include "phoebus_boundaries/phoebus_boundaries.hpp"
 #include "phoebus_driver.hpp"
 
-void ProcessBoundaryConditions(parthenon::ParthenonManager &pman);
-
 int main(int argc, char *argv[]) {
   parthenon::ParthenonManager pman;
 
@@ -55,7 +53,7 @@ int main(int argc, char *argv[]) {
 
   phoebus::ProblemModifier(pman.pinput.get());
 
-  ProcessBoundaryConditions(pman);
+  Boundaries::ProcessBoundaryConditions(pman);
 
   // call ParthenonInit to set up the mesh
   pman.ParthenonInitPackagesAndMesh();
@@ -80,41 +78,4 @@ int main(int argc, char *argv[]) {
   // MPI and Kokkos can no longer be used
 
   return (0);
-}
-
-// TODO(JMM): Move this somewhere else?
-void ProcessBoundaryConditions(parthenon::ParthenonManager &pman) {
-  // Ensure only allowed parthenon boundary conditions are used
-  const std::vector<std::string> inner_outer = {"i", "o"};
-  static const parthenon::BoundaryFace loc[][2] = {
-      {parthenon::BoundaryFace::inner_x1, parthenon::BoundaryFace::outer_x1},
-      {parthenon::BoundaryFace::inner_x2, parthenon::BoundaryFace::outer_x2},
-      {parthenon::BoundaryFace::inner_x3, parthenon::BoundaryFace::outer_x3}};
-  static const parthenon::BValFunc outflow[][2] = {
-      {Boundaries::OutflowInnerX1, Boundaries::OutflowOuterX1},
-      {Boundaries::OutflowInnerX2, Boundaries::OutflowOuterX2},
-      {Boundaries::OutflowInnerX3, Boundaries::OutflowOuterX3}};
-  static const parthenon::BValFunc reflect[][2] = {
-      {Boundaries::ReflectInnerX1, Boundaries::ReflectOuterX1},
-      {Boundaries::ReflectInnerX2, Boundaries::ReflectOuterX2},
-      {Boundaries::ReflectInnerX3, Boundaries::ReflectOuterX3}};
-
-  for (int d = 1; d <= 3; ++d) {
-    // outer = 0 for inner face, outer = 1 for outer face
-    for (int outer = 0; outer <= 1; ++outer) {
-      auto &face = inner_outer[outer];
-      const std::string name = face + "x" + std::to_string(d) + "_bc";
-      const std::string parth_bc = pman.pinput->GetString("parthenon/mesh", name);
-      PARTHENON_REQUIRE(parth_bc == "user" || parth_bc == "periodic",
-                        "Only \"user\" and \"periodic\" allowed for parthenon/mesh/" +
-                            name);
-
-      const std::string bc = pman.pinput->GetOrAddString("phoebus", name, "outflow");
-      if (bc == "reflect") {
-        pman.app_input->boundary_conditions[loc[d - 1][outer]] = reflect[d - 1][outer];
-      } else if (bc == "outflow") {
-        pman.app_input->boundary_conditions[loc[d - 1][outer]] = outflow[d - 1][outer];
-      } // periodic boundaries, which are handled by parthenon, so no need to set anything
-    }
-  }
 }

--- a/src/monopole_gr/interp_3d_to_1d.hpp
+++ b/src/monopole_gr/interp_3d_to_1d.hpp
@@ -222,8 +222,8 @@ GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry_t &geom,
 
     parthenon::Coordinates_t coords = p.GetCoords(b);
     const Real X1 = coords.x1v(i);
-    const Real X2 = coords.x1v(j);
-    const Real X3 = coords.x1v(k);
+    const Real X2 = coords.x2v(j);
+    const Real X3 = coords.x3v(k);
     transform(X1, X2, X3, C, c2s, s2c);
     const Real r = C[0];
     const Real th = C[1];

--- a/src/monopole_gr/interp_3d_to_1d.hpp
+++ b/src/monopole_gr/interp_3d_to_1d.hpp
@@ -27,6 +27,7 @@
 #include "fluid/tmunu.hpp"
 #include "geometry/geometry.hpp"
 #include "geometry/geometry_utils.hpp"
+#include "geometry/sph2cart.hpp"
 #include "monopole_gr/monopole_gr_base.hpp"
 #include "monopole_gr/monopole_gr_utils.hpp"
 #include "phoebus_utils/cell_locations.hpp"
@@ -39,19 +40,21 @@ namespace MonopoleGR {
 namespace impl {
 // Gets ADM mass rho0, adm momentum in r, jr, the rr component of S^i_j, and the trace
 // of the spatial stress tensor. Applies coordinate transforms if necessary.
-template <bool IS_CART, typename EnergyMomentum, typename Geometry, typename Pack>
+template <bool IS_CART, typename EnergyMomentum, typename Geometry, typename Transform,
+          typename Pack>
 KOKKOS_INLINE_FUNCTION void
-GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry &geom, const Pack &p,
-                      const int b, const int k, const int j, const int i, Real &rho0,
-                      Real &jr, Real &srr, Real &trcs);
+GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry &geom,
+                      const Transform &transform, const Pack &p, const int b, const int k,
+                      const int j, const int i, Real &rho0, Real &jr, Real &srr,
+                      Real &trcs);
 // Gets the radius r of a cell, as well as its width in radius dr, and
 // its volume element dv. Computes this for both Cartesian and
 // spherical coords.
-template <bool IS_CART, typename Pack>
+template <bool IS_CART, typename Transform, typename Pack>
 PORTABLE_INLINE_FUNCTION void
-GetCoordsAndCellWidthsHelper(const Pack &p, const int b, const int k, const int j,
-                             const int i, Real &r, Real &th, Real &ph, Real &dr,
-                             Real &dth, Real &dph, Real &dv);
+GetCoordsAndCellWidthsHelper(const Transform &transform, const Pack &p, const int b,
+                             const int k, const int j, const int i, Real &r, Real &th,
+                             Real &ph, Real &dr, Real &dth, Real &dph, Real &dv);
 
 } // namespace impl
 
@@ -64,8 +67,8 @@ TaskStatus InterpolateMatterTo1D(Data *rc) {
   using namespace impl;
 
   // Available in both mesh and meshblock
-  std::shared_ptr<StateDescriptor> const &pkg =
-      rc->GetParentPointer()->packages.Get("monopole_gr");
+  auto pparent = rc->GetParentPointer();
+  std::shared_ptr<StateDescriptor> const &pkg = pparent->packages.Get("monopole_gr");
   auto &params = pkg->AllParams();
 
   auto enabled = params.Get<bool>("enable_monopole_gr");
@@ -105,6 +108,15 @@ TaskStatus InterpolateMatterTo1D(Data *rc) {
   // PackIndexMap imap;
   auto pack = rc->PackVariables(vars);
 
+  // Always generate the transformation operator even if we don't need
+  // it.
+  // TODO(JMM): Long term we might want some logic to select the
+  // transformation actually in use... e.g., if we're doing something
+  // like a Sinh grid.
+  using Transformation_t = Geometry::SphericalToCartesian;
+  std::shared_ptr<StateDescriptor> const &geom_pkg = pparent->packages.Get("geometry");
+  auto transform = Geometry::GetTransformation<Transformation_t>(geom_pkg.get());
+
   // Available in all Container types
   IndexRange ib = rc->GetBoundsI(IndexDomain::interior);
   IndexRange jb = rc->GetBoundsJ(IndexDomain::interior);
@@ -124,12 +136,12 @@ TaskStatus InterpolateMatterTo1D(Data *rc) {
         // First compute the relevant conserved/prim vars
         Real matter_loc[4];
         GetMonopoleVarsHelper<is_monopole_cart>(
-            tmunu, geom, pack, b, k, j, i, matter_loc[Matter::RHO],
+            tmunu, geom, transform, pack, b, k, j, i, matter_loc[Matter::RHO],
             matter_loc[Matter::J_R], matter_loc[Matter::Srr], matter_loc[Matter::trcS]);
         // Next get coords and grid spacing
         Real r, th, ph, dr, dth, dph, dv;
-        GetCoordsAndCellWidthsHelper<is_monopole_cart>(pack, b, k, j, i, r, th, ph, dr,
-                                                       dth, dph, dv);
+        GetCoordsAndCellWidthsHelper<is_monopole_cart>(transform, pack, b, k, j, i, r, th,
+                                                       ph, dr, dth, dph, dv);
 
         // Bounds in the 1d grid We're wasteful here because I'm
         // paranoid. Need to make sure we don't need miss any cells in
@@ -161,11 +173,13 @@ TaskStatus InterpolateMatterTo1D(Data *rc) {
 // with type resolution and a constexpr if based on other templated types
 // Geometry_t is the geometry class in this case. Geometry is a namespace.
 namespace impl {
-template <bool IS_CART, typename EnergyMomentum, typename Geometry_t, typename Pack>
+template <bool IS_CART, typename EnergyMomentum, typename Geometry_t, typename Transform,
+          typename Pack>
 KOKKOS_INLINE_FUNCTION void
-GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry_t &geom, const Pack &p,
-                      const int b, const int k, const int j, const int i, Real &rho0,
-                      Real &jr, Real &srr, Real &trcs) {
+GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry_t &geom,
+                      const Transform &transform, const Pack &p, const int b, const int k,
+                      const int j, const int i, Real &rho0, Real &jr, Real &srr,
+                      Real &trcs) {
   // Tmunu and gcov
   constexpr int ND = Geometry::NDFULL;
   constexpr int NS = Geometry::NDSPACE;
@@ -198,29 +212,30 @@ GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry_t &geom, const
   // Only one branch is resolved at compile time
   // Thanks to the magic of templates and C++11.
   // constexpr if would be better though
+  // TODO(JMM): Should we remove branching and always apply something
+  // like an "identity" transform? That might be worth trying when we
+  // move to more exotic grids, like sinh.
   if (IS_CART) {
+    Real C[NS];
     Real ssph[NS][NS] = {0};
-    Real s2c[ND][ND], c2s[ND][ND];
-    Real r, th, ph;
+    Real s2c[NS][NS], c2s[NS][NS];
 
     parthenon::Coordinates_t coords = p.GetCoords(b);
-    Real X1 = coords.x1v(i);
-    Real X2 = coords.x1v(j);
-    Real X3 = coords.x1v(k);
-    // TODO(JMM): I kinda don't like this design. Should I redesign
-    // the coordinate transforms in the monopole class to be
-    // self-contained?
-    Geometry::MonopoleCoordTransforms::Cart2Sph(X1, X2, X3, r, th, ph);
-    Geometry::MonopoleCoordTransforms::S2C(r, th, ph, s2c);
-    Geometry::MonopoleCoordTransforms::C2S(X1, X2, X3, r, c2s);
+    const Real X1 = coords.x1v(i);
+    const Real X2 = coords.x1v(j);
+    const Real X3 = coords.x1v(k);
+    transform(X1, X2, X3, C, c2s, s2c);
+    const Real r = C[0];
+    const Real th = C[1];
+    const Real ph = C[2];
 
     // J
     jr = 0;
-    SPACELOOP(d) { jr += c2s[1][d + 1] * Scon[d]; }
+    SPACELOOP(d) { jr += c2s[0][d] * Scon[d]; }
     // S
     SPACELOOP2(l, ip) {
       SPACELOOP2(m, jp) {
-        ssph[ip][jp] += c2s[l + 1][ip + 1] * s2c[m + 1][jp + 1] *
+        ssph[ip][jp] += c2s[l][ip] * s2c[m][jp] *
                         (TConCov[ip + 1][jp + 1] + beta[ip] * TConCov[0][jp + 1]);
       }
     }
@@ -234,17 +249,17 @@ GetMonopoleVarsHelper(const EnergyMomentum &tmunu, const Geometry_t &geom, const
   }
 }
 
-template <bool IS_CART, typename Pack>
+template <bool IS_CART, typename Transform, typename Pack>
 PORTABLE_INLINE_FUNCTION void
-GetCoordsAndCellWidthsHelper(const Pack &p, const int b, const int k, const int j,
-                             const int i, Real &r, Real &th, Real &ph, Real &dr,
-                             Real &dth, Real &dph, Real &dv) {
+GetCoordsAndCellWidthsHelper(const Transform &transform, const Pack &p, const int b,
+                             const int k, const int j, const int i, Real &r, Real &th,
+                             Real &ph, Real &dr, Real &dth, Real &dph, Real &dv) {
   const parthenon::Coordinates_t &coords = p.GetCoords(b);
   if (IS_CART) {
-    Geometry::MonopoleCoordTransforms::Cart2Sph(
-        coords.x1v(k, j, i), coords.x2v(k, j, i), coords.x3v(k, j, i),
-        coords.Dx(1, k, j, i), coords.Dx(2, k, j, i), coords.Dx(3, k, j, i), r, th, ph,
-        dr, dth, dph);
+    transform.GetCoordsAndDerivatives(coords.x1v(k, j, i), coords.x2v(k, j, i),
+                                      coords.x3v(k, j, i), coords.Dx(1, k, j, i),
+                                      coords.Dx(2, k, j, i), coords.Dx(3, k, j, i), r, th,
+                                      ph, dr, dth, dph);
     dv = coords.Volume(k, j, i);
   } else {
     Interp3DTo1D::GetCoordsAndDerivsSph(k, j, i, coords, r, th, ph, dr, dth, dph, dv);

--- a/src/phoebus_boundaries/phoebus_boundaries.cpp
+++ b/src/phoebus_boundaries/phoebus_boundaries.cpp
@@ -297,4 +297,40 @@ TaskStatus ConvertBoundaryConditions(std::shared_ptr<MeshBlockData<Real>> &rc) {
   return TaskStatus::complete;
 }
 
+void ProcessBoundaryConditions(parthenon::ParthenonManager &pman) {
+  // Ensure only allowed parthenon boundary conditions are used
+  const std::vector<std::string> inner_outer = {"i", "o"};
+  static const parthenon::BoundaryFace loc[][2] = {
+      {parthenon::BoundaryFace::inner_x1, parthenon::BoundaryFace::outer_x1},
+      {parthenon::BoundaryFace::inner_x2, parthenon::BoundaryFace::outer_x2},
+      {parthenon::BoundaryFace::inner_x3, parthenon::BoundaryFace::outer_x3}};
+  static const parthenon::BValFunc outflow[][2] = {
+      {Boundaries::OutflowInnerX1, Boundaries::OutflowOuterX1},
+      {Boundaries::OutflowInnerX2, Boundaries::OutflowOuterX2},
+      {Boundaries::OutflowInnerX3, Boundaries::OutflowOuterX3}};
+  static const parthenon::BValFunc reflect[][2] = {
+      {Boundaries::ReflectInnerX1, Boundaries::ReflectOuterX1},
+      {Boundaries::ReflectInnerX2, Boundaries::ReflectOuterX2},
+      {Boundaries::ReflectInnerX3, Boundaries::ReflectOuterX3}};
+
+  for (int d = 1; d <= 3; ++d) {
+    // outer = 0 for inner face, outer = 1 for outer face
+    for (int outer = 0; outer <= 1; ++outer) {
+      auto &face = inner_outer[outer];
+      const std::string name = face + "x" + std::to_string(d) + "_bc";
+      const std::string parth_bc = pman.pinput->GetString("parthenon/mesh", name);
+      PARTHENON_REQUIRE(parth_bc == "user" || parth_bc == "periodic",
+                        "Only \"user\" and \"periodic\" allowed for parthenon/mesh/" +
+                            name);
+
+      const std::string bc = pman.pinput->GetOrAddString("phoebus", name, "outflow");
+      if (bc == "reflect") {
+        pman.app_input->boundary_conditions[loc[d - 1][outer]] = reflect[d - 1][outer];
+      } else if (bc == "outflow") {
+        pman.app_input->boundary_conditions[loc[d - 1][outer]] = outflow[d - 1][outer];
+      } // periodic boundaries, which are handled by parthenon, so no need to set anything
+    }
+  }
+}
+
 } // namespace Boundaries

--- a/src/phoebus_boundaries/phoebus_boundaries.hpp
+++ b/src/phoebus_boundaries/phoebus_boundaries.hpp
@@ -26,8 +26,21 @@ namespace Boundaries {
 
 void OutflowInnerX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
 void OutflowOuterX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+
 void ReflectInnerX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
 void ReflectOuterX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+
+void OutflowInnerX2(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+void OutflowOuterX2(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+
+void ReflectInnerX2(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+void ReflectOuterX2(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+
+void OutflowInnerX3(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+void OutflowOuterX3(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+
+void ReflectInnerX3(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
+void ReflectOuterX3(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
 
 TaskStatus ConvertBoundaryConditions(std::shared_ptr<MeshBlockData<Real>> &rc);
 

--- a/src/phoebus_boundaries/phoebus_boundaries.hpp
+++ b/src/phoebus_boundaries/phoebus_boundaries.hpp
@@ -18,11 +18,14 @@
 
 #include <memory>
 
+#include <parthenon_manager.hpp>
 #include <parthenon/package.hpp>
 #include <utils/error_checking.hpp>
 using namespace parthenon::package::prelude;
 
 namespace Boundaries {
+
+void ProcessBoundaryConditions(parthenon::ParthenonManager &pman);
 
 void OutflowInnerX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);
 void OutflowOuterX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse);

--- a/src/phoebus_boundaries/phoebus_boundaries.hpp
+++ b/src/phoebus_boundaries/phoebus_boundaries.hpp
@@ -18,8 +18,8 @@
 
 #include <memory>
 
-#include <parthenon_manager.hpp>
 #include <parthenon/package.hpp>
+#include <parthenon_manager.hpp>
 #include <utils/error_checking.hpp>
 using namespace parthenon::package::prelude;
 

--- a/src/phoebus_utils/history.hpp
+++ b/src/phoebus_utils/history.hpp
@@ -1,0 +1,70 @@
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#ifndef PHOEBUS_UTILS_HISTORY_HPP_
+#define PHOEBUS_UTILS_HISTORY_HPP_
+
+#include <string>
+#include <vector>
+
+#include <kokkos_abstraction.hpp>
+#include <parthenon/package.hpp>
+#include <parthenon_utils/error_checking.hpp>
+
+using namespace parthenon::package::prelude;
+
+/*
+ * History Template to build off of. Applies Reducer to MeshData on
+ * variable with varname. If variable is multi-d use idx to offset
+ * from first element. You should capture this object in a lambda to
+ * pass it to the Parthenon history machinery.
+ *
+ * TODO(JMM): This one is very simple. No volume weighting, no metric
+ * information. So it only works for min and max basically.  This can
+ * be made more sophisticated if needed, but I think this is fine for
+ * now.
+ */
+
+namespace History {
+
+template <typename Reducer_t>
+Real ReduceOneVar(MeshData<Real> *md, const std::string &varname, int idx = 0) {
+  const auto ib = md->GetBoundsI(IndexDomain::interior);
+  const auto jb = md->GetBoundsJ(IndexDomain::interior);
+  const auto kb = md->GetBoundsK(IndexDomain::interior);
+
+  PackIndexMap imap;
+  std::vector<std::string> vars = {varname};
+  const auto pack = md->PackVariables(vars, imap);
+  int ivar = imap[vars];
+  PARTHENON_REQUIRE(ivar.first >= 0, "Var must exist");
+  PARTHENON_REQUIRE(ivar.second >= ivar.first + idx, "Var must exist");
+
+  Real result = 0.0;
+  Reducer_t reducer(result);
+  parthenon::par_reduce(
+      DEFAULT_LOOP_PATTERN, "Phoebus History for " + varname, 0, pack.GetDim(5) - 1, kb.s,
+      kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
+        // join is a Kokkos construct
+        // that automatically does the
+        // reduction operation locally
+        reducer.join(lresult, pack(b, idx, k, j, i));
+      },
+      reducer);
+  return result;
+}
+
+} // namespace History
+
+#endif // PHOEBUS_UTILS_HISTORY_HPP_

--- a/src/phoebus_utils/history.hpp
+++ b/src/phoebus_utils/history.hpp
@@ -29,10 +29,8 @@ using namespace parthenon::package::prelude;
  * from first element. You should capture this object in a lambda to
  * pass it to the Parthenon history machinery.
  *
- * TODO(JMM): This one is very simple. No volume weighting, no metric
- * information. So it only works for min and max basically.  This can
- * be made more sophisticated if needed, but I think this is fine for
- * now.
+ * Works on max/min and on sums over densitized variables, which
+ * include the determinant of the metric.
  */
 
 namespace History {

--- a/src/phoebus_utils/history.hpp
+++ b/src/phoebus_utils/history.hpp
@@ -19,7 +19,7 @@
 
 #include <kokkos_abstraction.hpp>
 #include <parthenon/package.hpp>
-#include <parthenon_utils/error_checking.hpp>
+#include <utils/error_checking.hpp>
 
 using namespace parthenon::package::prelude;
 

--- a/src/tov/tov.cpp
+++ b/src/tov/tov.cpp
@@ -95,8 +95,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto ReducePress = [](MeshData<Real> *md) {
     return History::ReduceOneVar<Kokkos::Max<Real>>(md, fluid_prim::pressure, 0);
   };
+  auto ReduceDens = [](MeshData<Real> *md) {
+    return History::ReduceOneVar<Kokkos::Max<Real>>(md, fluid_prim::density, 0);
+  };
   parthenon::HstVar_list hst_vars = {};
   hst_vars.emplace_back(parthenon::HistoryOutputVar(HstMax, ReducePress, "max pressure"));
+  hst_vars.emplace_back(parthenon::HistoryOutputVar(HstMax, ReduceDens, "max Density"));
   params.Add(parthenon::hist_param_key, hst_vars);
 
   return tov;

--- a/src/tov/tov.cpp
+++ b/src/tov/tov.cpp
@@ -91,11 +91,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("tov_intrinsic_h", tov_intrinsic_h);
 
   // Redutions for history file
-  using HstMax = parthenon::UserHistoryOperation::max;
+  auto HstMax = parthenon::UserHistoryOperation::max;
   auto ReducePress = [](MeshData<Real> *md) {
-    return ReduceOneVar<Kokkos::Max<Real>>(md, fluid_prim::pressure, 0);
-  } parthenon::HstVar_list hst_vars = {};
-  hst_vars.emplace_back(parthenon::HistoryOutputVar(HstMax, ReducePress));
+    return History::ReduceOneVar<Kokkos::Max<Real>>(md, fluid_prim::pressure, 0);
+  };
+  parthenon::HstVar_list hst_vars = {};
+  hst_vars.emplace_back(parthenon::HistoryOutputVar(HstMax, ReducePress, "max pressure"));
   params.Add(parthenon::hist_param_key, hst_vars);
 
   return tov;

--- a/src/tov/tov.cpp
+++ b/src/tov/tov.cpp
@@ -22,6 +22,8 @@
 #include <parthenon/package.hpp>
 #include <utils/error_checking.hpp>
 
+using namespace parthenon::package::prelude;
+
 // Singularity
 #include <singularity-eos/eos/eos.hpp>
 
@@ -31,6 +33,8 @@
 #include "monopole_gr/monopole_gr_base.hpp"
 #include "monopole_gr/monopole_gr_interface.hpp"
 #include "monopole_gr/monopole_gr_utils.hpp"
+#include "phoebus_utils/history.hpp"
+#include "phoebus_utils/variables.hpp"
 
 #include "tov.hpp"
 
@@ -85,6 +89,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("tov_state_h", tov_state_h);
   params.Add("tov_intrinsic", tov_intrinsic);
   params.Add("tov_intrinsic_h", tov_intrinsic_h);
+
+  // Redutions for history file
+  using HstMax = parthenon::UserHistoryOperation::max;
+  auto ReducePress = [](MeshData<Real> *md) {
+    return ReduceOneVar<Kokkos::Max<Real>>(md, fluid_prim::pressure, 0);
+  } parthenon::HstVar_list hst_vars = {};
+  hst_vars.emplace_back(parthenon::HistoryOutputVar(HstMax, ReducePress));
+  params.Add(parthenon::hist_param_key, hst_vars);
 
   return tov;
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR finally rewrites the Cartesian monopole coordinate system tied to the monopole GR solver. I do the following:
1. Extend `ModifiedSystem` to support geometries with a time-dependent component. The coordinate transformation is assumed to be time-independent, but the geometry itself is allowed to evolve. This basically entails computing the `d/dt` components of the metric gradients and transforming them into the new coordinate system as appropriate, assuming zero cross-talk between the space and time components of the metric. Note this approach **only** works because the coordinate transform is time-independent.
2. Write a `SphericalToCartesian` transformation object, which I use in the `monopole_gr` interpolation from the 3d grid to the 1d grid to transform relevant quantities like the Jacobian.
3. Define the Cartesian monopole geometry as `using MonopoleCart=Modified<MonopoleSph, SphericalToCartesian>`
4. Wrap that in the `Analytic` and `Cached` geometry modifier templates
5. Profit.

I still need to test basically all of this, but it compiles and I think it's ready for feedback from y'all if you want to take a look. @brryan @jdolence @lroberts36 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
