### PR TITLE
check for lower-dimensions in interpolation. Resolves #111

### DIFF
--- a/src/geometry/cached_system.hpp
+++ b/src/geometry/cached_system.hpp
@@ -131,7 +131,7 @@ class Cached {
   }
   KOKKOS_INLINE_FUNCTION
   Real Lapse(int b, Real X0, Real X1, Real X2, Real X3) const {
-    return LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].alpha);
+    return LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].alpha);
   }
   KOKKOS_INLINE_FUNCTION
   Real Lapse(Real X0, Real X1, Real X2, Real X3) const {
@@ -151,9 +151,7 @@ class Cached {
   KOKKOS_INLINE_FUNCTION
   void ContravariantShift(int b, Real X0, Real X1, Real X2, Real X3,
                           Real beta[NDSPACE]) const {
-    SPACELOOP(d) {
-      beta[d] = LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].bcon + d);
-    }
+    SPACELOOP(d) { beta[d] = LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].bcon + d); }
   }
   KOKKOS_INLINE_FUNCTION
   void ContravariantShift(Real X0, Real X1, Real X2, Real X3, Real beta[NDSPACE]) const {
@@ -177,8 +175,7 @@ class Cached {
               Real gamma[NDSPACE][NDSPACE]) const {
     SPACELOOP2(m, n) {
       int offst = Utils::Flatten2(m + 1, n + 1, NDFULL); // gamma_{ij} = g_{ij}
-      gamma[m][n] =
-          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].gcov + offst);
+      gamma[m][n] = LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].gcov + offst);
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -205,8 +202,7 @@ class Cached {
                      Real gamma[NDSPACE][NDSPACE]) const {
     SPACELOOP2(m, n) {
       int offst = Utils::Flatten2(m, n, NDSPACE);
-      gamma[m][n] =
-          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].gamcon + offst);
+      gamma[m][n] = LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].gamcon + offst);
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -235,8 +231,7 @@ class Cached {
                        Real g[NDFULL][NDFULL]) const {
     SPACETIMELOOP2(mu, nu) {
       int offst = Utils::Flatten2(mu, nu, NDFULL);
-      g[mu][nu] =
-          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].gcov + offst);
+      g[mu][nu] = LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].gcov + offst);
     }
   }
   KOKKOS_INLINE_FUNCTION
@@ -268,13 +263,12 @@ class Cached {
     alpha2 *= alpha2;
     g[0][0] = -robust::ratio(1, alpha2);
     SPACELOOP(mu) {
-      Real num = LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx.bcon + mu);
+      Real num = LCInterp::Do(b, X1, X2, X3, pack_, idx.bcon + mu);
       g[mu + 1][0] = g[0][mu + 1] = ratio(num, alpha2);
     }
     SPACELOOP2(mu, nu) {
       int offst = Utils::Flatten2(mu, nu, NDSPACE);
-      g[mu + 1][nu + 1] =
-          LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx.gamcon + offst);
+      g[mu + 1][nu + 1] = LCInterp::Do(b, X1, X2, X3, pack_, idx.gamcon + offst);
       g[mu + 1][nu + 1] -= g[0][mu + 1] * g[0][nu + 1] * alpha2;
     }
   }
@@ -310,7 +304,7 @@ class Cached {
   }
   KOKKOS_INLINE_FUNCTION
   Real DetGamma(int b, Real X0, Real X1, Real X2, Real X3) const {
-    return LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, idx_[cent_].detgam);
+    return LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].detgam);
   }
   KOKKOS_INLINE_FUNCTION
   Real DetGamma(Real X0, Real X1, Real X2, Real X3) const {
@@ -368,8 +362,7 @@ class Cached {
           nvar_deriv_ * Utils::Flatten2(mu, nu, NDFULL) + idx_[cent_].dg - offset;
       dg[mu][nu][0] = 0.0; // gets overwritten if time-dependent metric
       for (int sigma = offset; sigma < NDFULL; sigma++) {
-        dg[mu][nu][sigma] =
-            LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_, flat + sigma);
+        dg[mu][nu][sigma] = LCInterp::Do(b, X1, X2, X3, pack_, flat + sigma);
       }
     }
   }
@@ -404,8 +397,7 @@ class Cached {
     const int offset = !time_dependent_;
     da[0] = 0; // gets overwritten if time-dependent metric
     for (int d = offset; d < NDFULL; ++d) {
-      da[d] = LCInterp::Do(axisymmetric_, b, X1, X2, X3, pack_,
-                           idx_[cent_].dalpha + d - offset);
+      da[d] = LCInterp::Do(b, X1, X2, X3, pack_, idx_[cent_].dalpha + d - offset);
     }
   }
   KOKKOS_INLINE_FUNCTION

--- a/src/pgen/check_cached_geom.cpp
+++ b/src/pgen/check_cached_geom.cpp
@@ -35,7 +35,7 @@ namespace check_cached_geom {
 
 KOKKOS_FORCEINLINE_FUNCTION
 Real RelErr(const Real a, const Real b) {
-  return 2 * robust::ratio(std::abs(a - b), a + b);
+  return std::min(2 * robust::ratio(std::abs(a - b), a + b), std::abs(a - b));
 }
 
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {

--- a/src/phoebus_utils/phoebus_interpolation.hpp
+++ b/src/phoebus_utils/phoebus_interpolation.hpp
@@ -69,7 +69,7 @@ KOKKOS_INLINE_FUNCTION void GetWeights(const Real x, const int nx,
  */
 template <typename Pack>
 KOKKOS_INLINE_FUNCTION Real Do3D(int b, const Real X1, const Real X2, const Real X3,
-                               const Pack &p, int v) {
+                                 const Pack &p, int v) {
   const auto &coords = p.GetCoords(b);
   int ix[3];
   weights_t w[3];
@@ -95,7 +95,7 @@ KOKKOS_INLINE_FUNCTION Real Do3D(int b, const Real X1, const Real X2, const Real
  */
 template <typename Pack>
 KOKKOS_INLINE_FUNCTION Real Do2D(int b, const Real X1, const Real X2, const Pack &p,
-                               int v) {
+                                 int v) {
   const auto &coords = p.GetCoords(b);
   int ix1, ix2;
   weights_t w1, w2;

--- a/src/phoebus_utils/phoebus_interpolation.hpp
+++ b/src/phoebus_utils/phoebus_interpolation.hpp
@@ -118,7 +118,7 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Pack &p, int v) {
   const auto &coords = p.GetCoords(b);
   int ix;
   weights_t w;
-  GetWeights<X1DIR>(X1, p.GetDim(1), coords, ix1, w1);
+  GetWeights<X1DIR>(X1, p.GetDim(1), coords, ix, w);
   return w[0] * p(b, v, 0, 0, ix) + w[1] * p(b, v, 0, 0, ix + 1);
 }
 

--- a/src/phoebus_utils/phoebus_interpolation.hpp
+++ b/src/phoebus_utils/phoebus_interpolation.hpp
@@ -138,9 +138,9 @@ KOKKOS_INLINE_FUNCTION Real Do1D(int b, const Real X1, const Pack &p, int v) {
 template <typename Pack>
 KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X3,
                                const Pack &p, int v) {
-  if (p.GetDim(3) > 0) {
+  if (p.GetDim(3) > 1) {
     return Do3D(b, X1, X2, X3, p, v);
-  } else if (p.GetDim(2) > 0) {
+  } else if (p.GetDim(2) > 1) {
     return Do2D(b, X1, X2, p, v);
   } else { // 1D
     return Do1D(b, X1, p, v);

--- a/src/phoebus_utils/phoebus_interpolation.hpp
+++ b/src/phoebus_utils/phoebus_interpolation.hpp
@@ -68,7 +68,7 @@ KOKKOS_INLINE_FUNCTION void GetWeights(const Real x, const int nx,
  * PARAM[IN] - v - variable index
  */
 template <typename Pack>
-KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X3,
+KOKKOS_INLINE_FUNCTION Real Do3D(int b, const Real X1, const Real X2, const Real X3,
                                const Pack &p, int v) {
   const auto &coords = p.GetCoords(b);
   int ix[3];
@@ -94,7 +94,7 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X
  * PARAM[IN] - v - variable index
  */
 template <typename Pack>
-KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Pack &p,
+KOKKOS_INLINE_FUNCTION Real Do2D(int b, const Real X1, const Real X2, const Pack &p,
                                int v) {
   const auto &coords = p.GetCoords(b);
   int ix1, ix2;
@@ -114,7 +114,7 @@ KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Pack &
  * PARAM[IN] - v - variable index
  */
 template <typename Pack>
-KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Pack &p, int v) {
+KOKKOS_INLINE_FUNCTION Real Do1D(int b, const Real X1, const Pack &p, int v) {
   const auto &coords = p.GetCoords(b);
   int ix;
   weights_t w;
@@ -139,11 +139,11 @@ template <typename Pack>
 KOKKOS_INLINE_FUNCTION Real Do(int b, const Real X1, const Real X2, const Real X3,
                                const Pack &p, int v) {
   if (p.GetDim(3) > 0) {
-    return Do(b, X1, X2, X3, p, v);
+    return Do3D(b, X1, X2, X3, p, v);
   } else if (p.GetDim(2) > 0) {
-    return Do(b, X1, X2, p, v);
+    return Do2D(b, X1, X2, p, v);
   } else { // 1D
-    return Do(b, X1, p, v);
+    return Do1D(b, X1, p, v);
   }
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In #111 @brryan pointed out that the cached geometry interpolation segfaults when in 1D because the interpolation operator tries to access invalid memory. This PR resolves the issue by introducing a 1D linear interpolation object. Also, rather than checking for axisymmetry, we now simply check the number of dimensions in the geometry pack. If `GetDim(3) < 2`, then we're axisymmetric If `GetDim(2) < 2`, then we're 1D.

I am still testing, but this is ready for review. @brryan can you try it to see if it resolves your issue?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
