### PR TITLE
Fix TOV

### DIFF
--- a/inputs/tov-static.pin
+++ b/inputs/tov-static.pin
@@ -1,0 +1,149 @@
+# © 2021. Triad National Security, LLC. All rights reserved.  This
+# program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad
+# National Security, LLC for the U.S.  Department of Energy/National
+# Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is
+# granted for itself and others acting on its behalf a nonexclusive,
+# paid-up, irrevocable worldwide license in this material to reproduce,
+# prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+
+# Tohlmann-Oppenheimer-Volkov star in hydrostatic equilibrium
+
+<phoebus>
+problem = tov
+#ix1_bc = outflow
+#ox1_bc = reflect
+ix1_bc = reflect
+ox1_bc = outflow
+
+<parthenon/job>
+problem_id  = tov # problem ID: basename of output filenames
+
+<parthenon/output1>
+variables = p.density,  &
+      	    c.density,  &
+            p.velocity, &
+            c.momentum, &
+            p.energy,   &
+            c.energy,   &
+	    pressure,	&
+      	    cs, &
+      	    p.ye, &
+      	    g.c.coord, &
+     	    g.n.coord, &
+	    g.c.alpha, &
+	    g.c.detgam, &
+	    g.c.gcov, &
+	    g.c.dg, &
+	    g.c.dalpha, &
+	    flux_divergence, &
+	    src_terms
+
+file_type   = hdf5      # Tabular data dump
+dt          = 5         # time increment between outputs
+
+<parthenon/time>
+nlim        = -1        # cycle limit
+tlim        = 5000      # time limit
+integrator  = rk2       # time integration algorithm
+ncycle_out  = 1         # interval for stdout summary info
+dt_init_fact = 1.e-6
+
+<parthenon/mesh>
+nghost = 4
+#refinement = adaptive
+#numlevel = 3
+
+nx1         = 1024        # Number of zones in X1-direction
+x1min       = 0           # minimum value of X1
+x1max       = 250         # maximum value of X1
+ix1_bc      = user        # Inner-X1 boundary condition flag
+ox1_bc      = user        # Outer-X1 boundary condition flag
+
+nx2         = 1             # Number of zones in X2-direction
+x2min       = 0             # minimum value of X2
+x2max       = 3.14159265359 # maximum value of X2. Pi
+ix2_bc      = reflecting    # Inner-X2 boundary condition flag
+ox2_bc      = reflecting    # Outer-X2 boundary condition flag
+
+nx3         = 1             # Number of zones in X3-direction
+x3min       = 0             # minimum value of X3
+x3max       = 6.28318530718 # maximum value of X3. 2*pi
+ix3_bc      = periodic      # Inner-X3 boundary condition flag
+ox3_bc      = periodic      # Outer-X3 boundary condition flfgag
+
+num_threads = 1         # maximum number of OMP threads
+
+<parthenon/meshblock>
+nx1 = 1024
+nx2 = 1
+nx3 = 1
+
+<parthenon/refinement0>
+field = c.c.bulk.rho
+method = derivative_order_1
+max_level = 3
+
+<eos>
+type = IdealGas
+Gamma = 2
+Cv = 1.0
+
+<physics>
+hydro = true
+he = false
+3t = false
+rad = false
+
+<fluid>
+xorder = 2
+cfl = 0.25
+riemann = llf
+recon = weno5
+c2p_max_iter = 1000
+Ye = false
+
+# Fixups aren't necessary for this problem,
+# especially with the Cowling approximation
+# and reflecting outer boundary.
+# But they also don't do any harm.
+<fixup>
+enable_floors = true
+enable_ceilings = true
+enable_flux_fixup = false
+enable_c2p_fixup = true
+floor_type = ConstantRhoSie
+rho0_floor = 1.0e-12
+sie0_floor = 1.0e-12
+rho_exp_floor = -2.0
+sie_exp_floor = -1.0
+ceiling_type = ConstantGamSie
+sie0_ceiling = 10.0;
+gam0_ceiling = 10.0;
+
+<monopole_gr>
+enabled = true
+npoints = 2048
+rout = 250
+# Disables time derivatives. Runs only at initialization
+force_static = true
+# Runs the first n subcycles. Then freezes. Source terms are not disabled.
+# -1 means it's always run.
+run_n_times = -1
+
+<tov>
+enabled = true
+Pc = 1e-6
+entropy = 8
+# pressure below which we terminate the TOV solver and transition to atmosphere
+Pmin = 1e-10
+# The atmosphere values in the problem generator for density and energy
+rhomin = 1e-12
+epsmin = 1e-12
+# Velocity perturbation
+vpert_amp = 0
+vpert_radius = 5
+vpert_sigma = 1

--- a/inputs/tov-static.pin
+++ b/inputs/tov-static.pin
@@ -1,4 +1,4 @@
-# © 2021. Triad National Security, LLC. All rights reserved.  This
+# © 2021-2022. Triad National Security, LLC. All rights reserved.  This
 # program was produced under U.S. Government contract 89233218CNA000001
 # for Los Alamos National Laboratory (LANL), which is operated by Triad
 # National Security, LLC for the U.S.  Department of Energy/National
@@ -11,11 +11,13 @@
 # publicly and display publicly, and to permit others to do so.
 
 # Tohlmann-Oppenheimer-Volkov star in hydrostatic equilibrium
+# This version uses a very compact star in the unstable branch
+# of the TOV solution. If the metric is allowed to evolve, a horizon
+# will form and the simulation will crash. Run this one
+# with a static metric, e.g., in the Cowling approximation.
 
 <phoebus>
 problem = tov
-#ix1_bc = outflow
-#ox1_bc = reflect
 ix1_bc = reflect
 ox1_bc = outflow
 
@@ -106,18 +108,14 @@ recon = weno5
 c2p_max_iter = 1000
 Ye = false
 
-# Fixups aren't necessary for this problem,
-# especially with the Cowling approximation
-# and reflecting outer boundary.
-# But they also don't do any harm.
 <fixup>
 enable_floors = true
 enable_ceilings = true
-enable_flux_fixup = false
+enable_flux_fixup = true
 enable_c2p_fixup = true
-floor_type = ConstantRhoSie
-rho0_floor = 1.0e-12
-sie0_floor = 1.0e-12
+floor_type = X1RhoSie
+rho0_floor = 1.0e-8
+sie0_floor = 1.0e-3
 rho_exp_floor = -2.0
 sie_exp_floor = -1.0
 ceiling_type = ConstantGamSie
@@ -136,13 +134,13 @@ run_n_times = -1
 
 <tov>
 enabled = true
-Pc = 1e-6
+Pc = 1e-2
 entropy = 8
 # pressure below which we terminate the TOV solver and transition to atmosphere
-Pmin = 1e-10
+Pmin = 1e-9
 # The atmosphere values in the problem generator for density and energy
-rhomin = 1e-12
-epsmin = 1e-12
+rhomin = 1e-10
+epsmin = 1e-10
 # Velocity perturbation
 vpert_amp = 0
 vpert_radius = 5

--- a/inputs/tov.pin
+++ b/inputs/tov.pin
@@ -1,4 +1,4 @@
-# © 2021. Triad National Security, LLC. All rights reserved.  This
+# © 2021-2022. Triad National Security, LLC. All rights reserved.  This
 # program was produced under U.S. Government contract 89233218CNA000001
 # for Los Alamos National Laboratory (LANL), which is operated by Triad
 # National Security, LLC for the U.S.  Department of Energy/National
@@ -14,9 +14,8 @@
 
 <phoebus>
 problem = tov
-bc_ix1 = reflect
-bc_ox1 = reflect  # reflecting outer boundary a bit better behaved
-#bc_ox1 = outflow # but outflow and reflecting both work fine
+ix1_bc = reflect
+ox1_bc = outflow
 
 <parthenon/job>
 problem_id  = tov # problem ID: basename of output filenames
@@ -42,11 +41,11 @@ variables = p.density,  &
 	    src_terms
 
 file_type   = hdf5      # Tabular data dump
-dt          = 1         # time increment between outputs
+dt          = 5         # time increment between outputs
 
 <parthenon/time>
 nlim        = -1        # cycle limit
-tlim        = 1000      # time limit
+tlim        = 5000      # time limit
 integrator  = rk2       # time integration algorithm
 ncycle_out  = 1         # interval for stdout summary info
 dt_init_fact = 1.e-6
@@ -56,7 +55,7 @@ nghost = 4
 #refinement = adaptive
 #numlevel = 3
 
-nx1         = 512         # Number of zones in X1-direction
+nx1         = 1024        # Number of zones in X1-direction
 x1min       = 0           # minimum value of X1
 x1max       = 250         # maximum value of X1
 ix1_bc      = user        # Inner-X1 boundary condition flag
@@ -77,7 +76,7 @@ ox3_bc      = periodic      # Outer-X3 boundary condition flfgag
 num_threads = 1         # maximum number of OMP threads
 
 <parthenon/meshblock>
-nx1 = 512
+nx1 = 1024
 nx2 = 1
 nx3 = 1
 
@@ -105,18 +104,14 @@ recon = weno5
 c2p_max_iter = 1000
 Ye = false
 
-# Fixups aren't necessary for this problem,
-# especially with the Cowling approximation
-# and reflecting outer boundary.
-# But they also don't do any harm.
 <fixup>
 enable_floors = true
 enable_ceilings = true
-enable_flux_fixup = false
+enable_flux_fixup = true
 enable_c2p_fixup = true
-floor_type = ConstantRhoSie
-rho0_floor = 1.0e-9
-sie0_floor = 1.0e-9
+floor_type = X1RhoSie
+rho0_floor = 1.0e-8
+sie0_floor = 1.0e-3
 rho_exp_floor = -2.0
 sie_exp_floor = -1.0
 ceiling_type = ConstantGamSie
@@ -125,7 +120,7 @@ gam0_ceiling = 10.0;
 
 <monopole_gr>
 enabled = true
-npoints = 4096
+npoints = 2048
 rout = 250
 # Disables time derivatives. Runs only at initialization
 force_static = false
@@ -146,7 +141,7 @@ enabled = true
 Pc = 1e-6
 entropy = 8
 # pressure below which we terminate the TOV solver and transition to atmosphere
-Pmin = 1e-12 
+Pmin = 1e-10
 # The atmosphere values in the problem generator for density and energy
 rhomin = 1e-12
 epsmin = 1e-12

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -75,12 +75,23 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       Real sp = pin->GetOrAddReal("fixup", "sie_exp_floor", -1.0);
       params.Add("floor", Floors(exp_x1_rho_sie_floor_tag, rho0, sie0, rp, sp));
     } else if (floor_type == "ExpX1RhoU") {
-      std::cout << "FOUND FLOOOR TYPE" << std::endl;
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(exp_x1_rho_u_floor_tag, rho0, sie0, rp, sp));
+    } else if (floor_type == "X1RhoSie") {
+      Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
+      Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
+      Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
+      Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
+      params.Add("floor", Floors(x1_rho_sie_floor_tag, rho0, sie0, rp, sp));
+    } else if (floor_type == "RRhoSie") {
+      Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
+      Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
+      Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
+      Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
+      params.Add("floor", Floors(r_rho_sie_floor_tag, rho0, sie0, rp, sp));
     } else {
       PARTHENON_FAIL("invalid <fixup>/floor_type input");
     }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR fixes three separate issues I discovered with TOV:
- The names of boundary conditions in the input deck changed between when the TOV was first set up and now. Boundary conditions now correct.
- In the PR where I added time step controls to the monopole solver, I accidentally introduced a bug that set the lapse to 1 always. The issue was the two arrays for the lapse and the lapse at the previous timestep were not being correctly and persistently swapped every cycle. This is now repaired.
- I add floors which can decay with radius, which behave better and cause less perturbations to the star.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
