### PR TITLE
Don't output flux div for fluid if fluid isnt active

### DIFF
--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -493,8 +493,7 @@ TaskStatus ConservedToPrimitiveClassic(T *rc, const IndexRange &ib, const IndexR
 TaskStatus CopyFluxDivergence(MeshBlockData<Real> *rc) {
   auto *pmb = rc->GetParentPointer().get();
   auto &fluid = pmb->packages.Get("fluid");
-  if (!fluid->Param<bool>("active"))
-    return TaskStatus::complete;
+  if (!fluid->Param<bool>("active")) return TaskStatus::complete;
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -492,6 +492,9 @@ TaskStatus ConservedToPrimitiveClassic(T *rc, const IndexRange &ib, const IndexR
 #if SET_FLUX_SRC_DIAGS
 TaskStatus CopyFluxDivergence(MeshBlockData<Real> *rc) {
   auto *pmb = rc->GetParentPointer().get();
+  auto &fluid = pmb->packages.Get("fluid");
+  if (!fluid->Param<bool>("active"))
+    return TaskStatus::complete;
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

If `PHOEBUS_FLUX_AND_SRC_DIAGS` was `ON` but the fluid was not `active`, there was a memory error trying to store the fluid fluxes because they weren't being allocated. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
