### PR TITLE
epsmin floor was being set to rhomin floor value in tov pgen

### DIFF
--- a/src/pgen/tov.cpp
+++ b/src/pgen/tov.cpp
@@ -62,7 +62,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   const auto pmin = tov_pkg->Param<Real>("pmin");
   const Real rhomin = pin->GetOrAddReal("tov", "rhomin", 1e-12);
-  const Real epsmin = pin->GetOrAddReal("tov", "rhomin", 1e-12);
+  const Real epsmin = pin->GetOrAddReal("tov", "epsmin", 1e-12);
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes tov init bug where `epsmin` floor was being set to `rhomin` value

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Explain what you did.
