### PR TITLE
reworked task-lists, in PostInititalizationCommunications()

### DIFF
--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -108,36 +108,55 @@ void PhoebusDriver::PostInitializationCommunication() {
     rad_mocmc_active = (rad->Param<std::string>("method") == "mocmc");
   }
 
-  TaskRegion &async_region = tc.AddRegion(blocks.size());
+  TaskRegion &async_region = tc.AddRegion(3);
+
+  // leading per-block tasks
+  auto &tl0 = async_region[0];
   for (int ib = 0; ib < blocks.size(); ib++) {
     auto pmb = blocks[ib].get();
-    auto &tl = async_region[ib];
     auto &sc = pmb->meshblock_data.Get();
-    auto &md =
-        pmesh->mesh_data.GetOrAdd(stage_name[0], ib); // TODO(BRR) This gives an empty md
 
-    auto start_recv = tl.AddTask(none, &MeshBlockData<Real>::StartReceiving, sc.get(),
+    auto start_recv = tl0.AddTask(none, &MeshBlockData<Real>::StartReceiving, sc.get(),
                                  BoundaryCommSubset::all);
-    auto send =
-        tl.AddTask(start_recv, parthenon::cell_centered_bvars::SendBoundaryBuffers, md);
-    auto recv =
-        tl.AddTask(send, parthenon::cell_centered_bvars::ReceiveBoundaryBuffers, md);
-    auto fill_from_bufs =
-        tl.AddTask(recv, parthenon::cell_centered_bvars::SetBoundaries, md);
+  }
+
+  // tasks that span <md>
+  auto &tl1 = async_region[1];
+  auto &md = pmesh->mesh_data.GetOrAdd(stage_name[0], 0);
+
+  auto send =
+     tl1.AddTask(none, parthenon::cell_centered_bvars::SendBoundaryBuffers, md);
+
+  auto recv =
+     tl1.AddTask(send, parthenon::cell_centered_bvars::ReceiveBoundaryBuffers, md);
+
+  auto fill_from_bufs =
+     tl1.AddTask(recv, parthenon::cell_centered_bvars::SetBoundaries, md);
+
+  // tailing per-block-tasks
+  auto &tl2 = async_region[2];
+  for (int ib = 0; ib < blocks.size(); ib++) {
+    auto pmb = blocks[ib].get();
+    auto &sc = pmb->meshblock_data.Get();
+
     auto clear_comm_flags =
-        tl.AddTask(fill_from_bufs, &MeshBlockData<Real>::ClearBoundary, sc.get(),
-                   BoundaryCommSubset::all);
+       tl2.AddTask(none, &MeshBlockData<Real>::ClearBoundary,
+                  sc.get(),
+                  BoundaryCommSubset::all);
 
-    auto prolongBound = tl.AddTask(clear_comm_flags, parthenon::ProlongateBoundaries, sc);
+    auto prolongBound =
+       tl2.AddTask(clear_comm_flags, parthenon::ProlongateBoundaries, sc);
 
-    auto set_bc = tl.AddTask(prolongBound, parthenon::ApplyBoundaryConditions, sc);
+    auto set_bc =
+       tl2.AddTask(prolongBound, parthenon::ApplyBoundaryConditions, sc);
 
-    auto convert_bc = tl.AddTask(set_bc, Boundaries::ConvertBoundaryConditions, sc);
+    auto convert_bc =
+       tl2.AddTask(set_bc, Boundaries::ConvertBoundaryConditions, sc);
 
     // Radiation should actually be included in ConvertBoundaryConditions
     // using MDT = std::remove_pointer<decltype(sc.get())>::type;
-    // auto momentp2c = tl.AddTask(convert_bc, radiation::MomentPrim2Con<MDT>, sc.get(),
-    // IndexDomain::entire);
+    // auto momentp2c = tl2.AddTask(convert_bc, radiation::MomentPrim2Con<MDT>, sc.get(),
+    //                              IndexDomain::entire);
   }
 
   tc.Execute();


### PR DESCRIPTION

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Refactored task-lists in PhoebusDriver::PostInitializationCommunications(), to avoid a segfault with our 3D-blast-wave input.

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->


There was a comment in the original:
```c++
for (int ib = 0; ib < blocks.size(); ib++) {
   ...
   auto &md = pmesh->mesh_data.GetOrAdd(stage_name[0], ib); // ... gives an empty md
```
At this point in initialization, all the blocks have been allocated in a single stage.  Thus, the second iteration finds nothing.  This (empty md) produces a SEGV on the 3D-blast-wave input deck.

The code appears to intend the creation of a series of TaskLists in a single Region, each of which (TL) is filled with a series of tasks pertaining to a single block, starting with enabling receives, then performing exchanges, etc.  However, the exchanges are actually performed with an entire MeshData object, covering all the blocks (?), which can be handled by a single task.

If that analysis is correct, then the present approach resolves the problem by reformulating the inits into just three TaskLists: The first is a pass through all the blocks, enabling recvs.  The second does the MD-wide tasks to do the exchanges.  Finally, there's per-block boundary maintenance.

A question to consider is how the existing code was able to function.  Perhaps other input decks don't invoke the second iteration?  Or do they have initializations that result in per-block stages?  If the latter, then the current changes should continue to work for those cases.

Tested with OMP and MPI, but only on A64FX, and only with our 3D_blast_wave input.

Needs a pass through whatever unit tests are available.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ X] Format your changes by calling `scripts/bash/format.sh`.
- [ X] Explain what you did.
