### PR TITLE
Fix flux fixup for X2 BCs

### DIFF
--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -476,6 +476,8 @@ TaskStatus FixFluxes(MeshBlockData<Real> *rc) {
   auto fluid = pmb->packages.Get("fluid");
   const std::string ix1_bc = fluid->Param<std::string>("ix1_bc");
   const std::string ox1_bc = fluid->Param<std::string>("ox1_bc");
+  const std::string ix2_bc = fluid->Param<std::string>("ix2_bc");
+  const std::string ox2_bc = fluid->Param<std::string>("ox2_bc");
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
@@ -534,61 +536,65 @@ TaskStatus FixFluxes(MeshBlockData<Real> *rc) {
   if (ndim == 1) return TaskStatus::complete;
 
   // x2-direction
-  if (pmb->boundary_flag[BoundaryFace::inner_x2] == BoundaryFlag::outflow) {
-    auto flux =
-        rc->PackVariablesAndFluxes(std::vector<std::string>({fluid_cons::density}),
-                                   std::vector<std::string>({fluid_cons::density}));
-    parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.s, jb.s,
-        ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
-          flux.flux(X2DIR, 0, k, j, i) = std::min(flux.flux(X2DIR, 0, k, j, i), 0.0);
-        });
-  } else if (pmb->boundary_flag[BoundaryFace::inner_x2] == BoundaryFlag::reflect) {
-    PackIndexMap imap;
-    auto flux = rc->PackVariablesAndFluxes(
-        std::vector<std::string>(
-            {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
-        std::vector<std::string>(
-            {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
-        imap);
-    const int cmom_lo = imap[c::momentum].first;
-    const int cmom_hi = imap[c::momentum].second;
-    parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.s, jb.s,
-        ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
-          flux.flux(X2DIR, 0, k, j, i) = 0.0;
-          flux.flux(X2DIR, 1, k, j, i) = 0.0;
-          flux.flux(X2DIR, cmom_lo, k, j, i) = 0.0;
-          flux.flux(X2DIR, cmom_lo + 2, k, j, i) = 0.0;
-        });
+  if (pmb->boundary_flag[BoundaryFace::inner_x2] == BoundaryFlag::user) {
+    if (ix2_bc == "outflow") {
+      auto flux =
+          rc->PackVariablesAndFluxes(std::vector<std::string>({fluid_cons::density}),
+                                     std::vector<std::string>({fluid_cons::density}));
+      parthenon::par_for(
+          DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.s, jb.s,
+          ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
+            flux.flux(X2DIR, 0, k, j, i) = std::min(flux.flux(X2DIR, 0, k, j, i), 0.0);
+          });
+    } else if (ix2_bc == "reflect") {
+      PackIndexMap imap;
+      auto flux = rc->PackVariablesAndFluxes(
+          std::vector<std::string>(
+              {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
+          std::vector<std::string>(
+              {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
+          imap);
+      const int cmom_lo = imap[c::momentum].first;
+      const int cmom_hi = imap[c::momentum].second;
+      parthenon::par_for(
+          DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.s, jb.s,
+          ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
+            flux.flux(X2DIR, 0, k, j, i) = 0.0;
+            flux.flux(X2DIR, 1, k, j, i) = 0.0;
+            flux.flux(X2DIR, cmom_lo, k, j, i) = 0.0;
+            flux.flux(X2DIR, cmom_lo + 2, k, j, i) = 0.0;
+          });
+    }
   }
-  if (pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::outflow) {
-    auto flux =
-        rc->PackVariablesAndFluxes(std::vector<std::string>({fluid_cons::density}),
-                                   std::vector<std::string>({fluid_cons::density}));
-    parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.e + 1,
-        jb.e + 1, ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
-          flux.flux(X2DIR, 0, k, j, i) = std::max(flux.flux(X2DIR, 0, k, j, i), 0.0);
-        });
-  } else if (pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::reflect) {
-    PackIndexMap imap;
-    auto flux = rc->PackVariablesAndFluxes(
-        std::vector<std::string>(
-            {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
-        std::vector<std::string>(
-            {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
-        imap);
-    const int cmom_lo = imap[c::momentum].first;
-    const int cmom_hi = imap[c::momentum].second;
-    parthenon::par_for(
-        DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.e + 1,
-        jb.e + 1, ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
-          flux.flux(X2DIR, 0, k, j, i) = 0.0;
-          flux.flux(X2DIR, 1, k, j, i) = 0.0;
-          flux.flux(X2DIR, cmom_lo, k, j, i) = 0.0;
-          flux.flux(X2DIR, cmom_lo + 2, k, j, i) = 0.0;
-        });
+  if (pmb->boundary_flag[BoundaryFace::outer_x2] == BoundaryFlag::user) {
+    if (ox2_bc == "outflow") {
+      auto flux =
+          rc->PackVariablesAndFluxes(std::vector<std::string>({fluid_cons::density}),
+                                     std::vector<std::string>({fluid_cons::density}));
+      parthenon::par_for(
+          DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.e + 1,
+          jb.e + 1, ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
+            flux.flux(X2DIR, 0, k, j, i) = std::max(flux.flux(X2DIR, 0, k, j, i), 0.0);
+          });
+    } else if (ox2_bc == "reflect") {
+      PackIndexMap imap;
+      auto flux = rc->PackVariablesAndFluxes(
+          std::vector<std::string>(
+              {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
+          std::vector<std::string>(
+              {fluid_cons::density, fluid_cons::energy, fluid_cons::momentum}),
+          imap);
+      const int cmom_lo = imap[c::momentum].first;
+      const int cmom_hi = imap[c::momentum].second;
+      parthenon::par_for(
+          DEFAULT_LOOP_PATTERN, "FixFluxes::x2", DevExecSpace(), kb.s, kb.e, jb.e + 1,
+          jb.e + 1, ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
+            flux.flux(X2DIR, 0, k, j, i) = 0.0;
+            flux.flux(X2DIR, 1, k, j, i) = 0.0;
+            flux.flux(X2DIR, cmom_lo, k, j, i) = 0.0;
+            flux.flux(X2DIR, cmom_lo + 2, k, j, i) = 0.0;
+          });
+    }
   }
 
   if (ndim == 2) return TaskStatus::complete;

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -383,7 +383,7 @@ class ConToPrim {
     v(peng) *= v(prho);
     v(prs) = eos.PressureFromDensityTemperature(v(prho), v(tmp), eos_lambda);
     v(gm1) = eos.BulkModulusFromDensityTemperature(v(prho), v(tmp), eos_lambda) / v(prs);
-    PARTHENON_DEBUG_REQUIRE(v(prs) > robust::EPS(), "Pressure must be positive");
+    PARTHENON_DEBUG_REQUIRE(v(prs) > robust::SMALL(), "Pressure must be positive");
 
     Real vel[3];
     SPACELOOP(i) {

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -154,6 +154,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("ix1_bc", ix1_bc);
   const std::string ox1_bc = pin->GetString("phoebus", "ox1_bc");
   params.Add("ox1_bc", ox1_bc);
+  const std::string ix2_bc = pin->GetString("phoebus", "ix2_bc");
+  params.Add("ix2_bc", ix2_bc);
+  const std::string ox2_bc = pin->GetString("phoebus", "ox2_bc");
+  params.Add("ox2_bc", ox2_bc);
 
   int ndim = 1;
   if (pin->GetInteger("parthenon/mesh", "nx3") > 1)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

The switch to using `user` BCs for the X2 BCs as well as the X1 BCs didn't loop the change through fix flux -- this PR fixes that. Also, `EPS` ~ 1.e-15 is now `SMALL` ~ 1.e-300 in a debug check in `con2prim_robust` -- we don't want our pressures to be restricted to > 1.e-15. This broke the torus in debug mode, for example. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
