### PR TITLE
add an input option to short-circuit post-init-comms

### DIFF
--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -91,6 +91,10 @@ TaskListStatus PhoebusDriver::Step() {
 // TODO(BRR) This is required for periodic BCs, unless the issue is radiation not being
 // included in ConvertBoundaryConditions
 void PhoebusDriver::PostInitializationCommunication() {
+  auto phoebus_package = pmesh->packages.Get("phoebus");
+  auto do_post_init_comms = phoebus_package->Param<bool>("do_post_init_comms");
+  if (!do_post_init_comms) return;
+
   TaskCollection tc;
   TaskID none(0);
   BlockList_t &blocks = pmesh->block_list;

--- a/src/phoebus_package.cpp
+++ b/src/phoebus_package.cpp
@@ -33,7 +33,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("tlim", pin->GetReal("parthenon/time", "tlim"));
   params.Add("nlim", pin->GetReal("parthenon/time", "nlim"));
   params.Add("integrator", pin->GetString("parthenon/time", "integrator"));
-  params.Add("do_post_init_comms", pin->GetOrAddBoolean("phoebus","do_post_init_comms",false));
+  params.Add("do_post_init_comms",
+             pin->GetOrAddBoolean("phoebus", "do_post_init_comms", false));
 
   // Store unit conversions
   params.Add("unit_conv", phoebus::UnitConversions(pin));

--- a/src/phoebus_package.cpp
+++ b/src/phoebus_package.cpp
@@ -33,6 +33,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("tlim", pin->GetReal("parthenon/time", "tlim"));
   params.Add("nlim", pin->GetReal("parthenon/time", "nlim"));
   params.Add("integrator", pin->GetString("parthenon/time", "integrator"));
+  params.Add("do_post_init_comms", pin->GetOrAddBoolean("phoebus","do_post_init_comms",false));
 
   // Store unit conversions
   params.Add("unit_conv", phoebus::UnitConversions(pin));


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Given the segfaults happening due to `PostInitializationCommunication`, I'm adding a runtime option to disable it. Adds an input parameter in the `phoebus` block.

In the long term, we need to pull #118 through. Alternatively, changes upstream in Parthenon may make this driver stage unnecessary. @brryan what are your thoughts?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
