### PR TITLE
Fix GRMHD torus

### DIFF
--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -237,7 +237,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("src_failure_strategy", src_failure_strategy);
 
   const bool c2p_failure_force_fixup_both =
-      pin->GetOrAddBoolean("fixup", "c2p_failure_force_fixup_both", true);
+      pin->GetOrAddBoolean("fixup", "c2p_failure_force_fixup_both", false);
   params.Add("c2p_failure_force_fixup_both", c2p_failure_force_fixup_both);
 
   params.Add("bounds",

--- a/src/microphysics/opac_phoebus/opac_phoebus.cpp
+++ b/src/microphysics/opac_phoebus/opac_phoebus.cpp
@@ -44,6 +44,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
   bool do_rad = pin->GetBoolean("physics", "rad");
   if (!do_rad) {
+    params.Add("opacities", Opacities());
     return pkg;
   }
 

--- a/src/microphysics/opac_phoebus/opac_phoebus.hpp
+++ b/src/microphysics/opac_phoebus/opac_phoebus.hpp
@@ -39,6 +39,8 @@ class Opacities {
   using MeanSOpacity = singularity::neutrinos::MeanSOpacity;
 
  public:
+  Opacities() = default;
+  KOKKOS_FUNCTION
   Opacities(const Opacity &opac, const MeanOpacity &m_opac, const SOpacity &s_opac,
             const MeanSOpacity &m_s_opac)
       : opac_(opac), m_opac_(m_opac), s_opac_(s_opac), m_s_opac_(m_s_opac) {}


### PR DESCRIPTION
I recently broke the GRMHD torus in my #134 PR. This PR fixes that, by providing a default `Opacities()` object in params if radiation is disabled. 

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
