### PR TITLE
Mean opacity constructors expect CGS unit opacities, not NonCGSUnits<>!

### DIFF
--- a/scripts/python/phoedf.py
+++ b/scripts/python/phoedf.py
@@ -62,7 +62,6 @@ class phoedf(phdf.phdf):
         self.flatgcov[:,:,:,:,flatten_indices(2, 2)] = 1.
         self.flatgcov[:,:,:,:,flatten_indices(3, 3)] = 1.
     self.gcov = np.zeros([self.NumBlocks, self.Nx3, self.Nx2, self.Nx1, 4, 4])
-    print(self.flatgcov.shape)
     for mu in range(4):
       for nu in range(4):
         self.gcov[:,:,:,:,mu,nu] = self.flatgcov[:,:,:,:,flatten_indices(mu,nu)]

--- a/src/microphysics/opac_phoebus/opac_phoebus.cpp
+++ b/src/microphysics/opac_phoebus/opac_phoebus.cpp
@@ -75,12 +75,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     if (scale_free) {
       singularity::neutrinos::Opacity opacity_host = ScaleFree(kappa);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.opacity_baseunits", opacity_host);
       params.Add("h.opacity", opacity_host);
       params.Add("d.opacity", opacity_device);
     } else {
       singularity::neutrinos::Opacity opacity_host =
           NonCGSUnits<Gray>(Gray(kappa), time_unit, mass_unit, length_unit, temp_unit);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.opacity_baseunits", Gray(kappa));
       params.Add("h.opacity", opacity_host);
       params.Add("d.opacity", opacity_device);
     }
@@ -91,13 +93,13 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     params.Add("C", C);
     params.Add("numin", numin);
     params.Add("numax", numax);
-    printf("C: %e numin: %e numax: %e\n", C, numin, numax);
 
     PARTHENON_REQUIRE(!scale_free, "Must have CGS scaling for tophat opacities!");
 
     singularity::neutrinos::Opacity opacity_host = NonCGSUnits<Tophat>(
         Tophat(C, numin, numax), time_unit, mass_unit, length_unit, temp_unit);
     auto opacity_device = opacity_host.GetOnDevice();
+    params.Add("h.opacity_baseunits", Tophat(C, numin, numax));
     params.Add("h.opacity", opacity_host);
     params.Add("d.opacity", opacity_device);
   } else if (opacity_type == "gray") {
@@ -107,12 +109,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     if (scale_free) {
       singularity::neutrinos::Opacity opacity_host = ScaleFree(kappa);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.opacity_baseunits", opacity_host);
       params.Add("h.opacity", opacity_host);
       params.Add("d.opacity", opacity_device);
     } else {
       singularity::neutrinos::Opacity opacity_host =
           NonCGSUnits<Gray>(Gray(kappa), time_unit, mass_unit, length_unit, temp_unit);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.opacity_baseunits", Gray(kappa));
       params.Add("h.opacity", opacity_host);
       params.Add("d.opacity", opacity_device);
     }
@@ -126,6 +130,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     singularity::neutrinos::Opacity opacity_host = NonCGSUnits<SpinerOpac>(
         SpinerOpac(filename), time_unit, mass_unit, length_unit, temp_unit);
     auto opacity_device = opacity_host.GetOnDevice();
+    params.Add("h.opacity_baseunits", SpinerOpac(filename));
     params.Add("h.opacity", opacity_host);
     params.Add("d.opacity", opacity_device);
 #else
@@ -134,7 +139,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   }
 
   {
-    auto opacity_host = params.Get<singularity::neutrinos::Opacity>("h.opacity");
+    auto opacity_host =
+        params.Get<singularity::neutrinos::Opacity>("h.opacity_baseunits");
     const Real YeMin = pin->GetOrAddReal("mean_opacity", "yemin", 0.1);
     const Real YeMax = pin->GetOrAddReal("mean_opacity", "yemax", 0.5);
     const int NYe = pin->GetOrAddInteger("mean_opacity", "nye", 10);
@@ -196,6 +202,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     if (scale_free) {
       singularity::neutrinos::SOpacity opacity_host = ScaleFreeS(kappa, 1.);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.s_opacity_baseunits", opacity_host);
       params.Add("h.s_opacity", opacity_host);
       params.Add("d.s_opacity", opacity_device);
     } else {
@@ -203,6 +210,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
           NonCGSUnitsS<GrayS>(GrayS(kappa * avg_particle_mass, avg_particle_mass),
                               time_unit, mass_unit, length_unit, temp_unit);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.s_opacity_baseunits",
+                 GrayS(kappa * avg_particle_mass, avg_particle_mass));
       params.Add("h.s_opacity", opacity_host);
       params.Add("d.s_opacity", opacity_device);
     }
@@ -213,6 +222,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     if (scale_free) {
       singularity::neutrinos::SOpacity opacity_host = ScaleFreeS(kappa, 1.);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.s_opacity_baseunits", opacity_host);
       params.Add("h.s_opacity", opacity_host);
       params.Add("d.s_opacity", opacity_device);
     } else {
@@ -220,13 +230,16 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
           NonCGSUnitsS<GrayS>(GrayS(kappa * avg_particle_mass, avg_particle_mass),
                               time_unit, mass_unit, length_unit, temp_unit);
       auto opacity_device = opacity_host.GetOnDevice();
+      params.Add("h.s_opacity_baseunits",
+                 GrayS(kappa * avg_particle_mass, avg_particle_mass));
       params.Add("h.s_opacity", opacity_host);
       params.Add("d.s_opacity", opacity_device);
     }
   }
 
   {
-    auto opacity_host = params.Get<singularity::neutrinos::SOpacity>("h.s_opacity");
+    auto opacity_host =
+        params.Get<singularity::neutrinos::SOpacity>("h.s_opacity_baseunits");
     const Real YeMin = pin->GetOrAddReal("mean_opacity", "yemin", 0.1);
     const Real YeMax = pin->GetOrAddReal("mean_opacity", "yemax", 0.5);
     const int NYe = pin->GetOrAddInteger("mean_opacity", "nye", 10);

--- a/src/microphysics/opac_phoebus/opac_phoebus.cpp
+++ b/src/microphysics/opac_phoebus/opac_phoebus.cpp
@@ -82,7 +82,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       singularity::neutrinos::Opacity opacity_host =
           NonCGSUnits<Gray>(Gray(kappa), time_unit, mass_unit, length_unit, temp_unit);
       auto opacity_device = opacity_host.GetOnDevice();
-      params.Add("h.opacity_baseunits", Gray(kappa));
+      singularity::neutrinos::Opacity opacity_host_baseunits = Gray(kappa);
+      params.Add("h.opacity_baseunits", opacity_host_baseunits);
       params.Add("h.opacity", opacity_host);
       params.Add("d.opacity", opacity_device);
     }
@@ -99,7 +100,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     singularity::neutrinos::Opacity opacity_host = NonCGSUnits<Tophat>(
         Tophat(C, numin, numax), time_unit, mass_unit, length_unit, temp_unit);
     auto opacity_device = opacity_host.GetOnDevice();
-    params.Add("h.opacity_baseunits", Tophat(C, numin, numax));
+    singularity::neutrinos::Opacity opacity_host_baseunits = Tophat(C, numin, numax);
+    params.Add("h.opacity_baseunits", opacity_host_baseunits);
     params.Add("h.opacity", opacity_host);
     params.Add("d.opacity", opacity_device);
   } else if (opacity_type == "gray") {
@@ -116,7 +118,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       singularity::neutrinos::Opacity opacity_host =
           NonCGSUnits<Gray>(Gray(kappa), time_unit, mass_unit, length_unit, temp_unit);
       auto opacity_device = opacity_host.GetOnDevice();
-      params.Add("h.opacity_baseunits", Gray(kappa));
+      singularity::neutrinos::Opacity opacity_host_baseunits = Gray(kappa);
+      params.Add("h.opacity_baseunits", opacity_host_baseunits);
       params.Add("h.opacity", opacity_host);
       params.Add("d.opacity", opacity_device);
     }
@@ -130,7 +133,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     singularity::neutrinos::Opacity opacity_host = NonCGSUnits<SpinerOpac>(
         SpinerOpac(filename), time_unit, mass_unit, length_unit, temp_unit);
     auto opacity_device = opacity_host.GetOnDevice();
-    params.Add("h.opacity_baseunits", SpinerOpac(filename));
+    singularity::neutrinos::Opacity opacity_host_baseunits = SpinerOpac(filename);
+    params.Add("h.opacity_baseunits", opacity_host_baseunits);
     params.Add("h.opacity", opacity_host);
     params.Add("d.opacity", opacity_device);
 #else
@@ -209,9 +213,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       singularity::neutrinos::SOpacity opacity_host =
           NonCGSUnitsS<GrayS>(GrayS(kappa * avg_particle_mass, avg_particle_mass),
                               time_unit, mass_unit, length_unit, temp_unit);
+      singularity::neutrinos::SOpacity opacity_host_baseunits =
+          GrayS(kappa * avg_particle_mass, avg_particle_mass);
       auto opacity_device = opacity_host.GetOnDevice();
-      params.Add("h.s_opacity_baseunits",
-                 GrayS(kappa * avg_particle_mass, avg_particle_mass));
+      params.Add("h.s_opacity_baseunits", opacity_host_baseunits);
       params.Add("h.s_opacity", opacity_host);
       params.Add("d.s_opacity", opacity_device);
     }
@@ -229,9 +234,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       singularity::neutrinos::SOpacity opacity_host =
           NonCGSUnitsS<GrayS>(GrayS(kappa * avg_particle_mass, avg_particle_mass),
                               time_unit, mass_unit, length_unit, temp_unit);
+      singularity::neutrinos::SOpacity opacity_host_baseunits =
+          GrayS(kappa * avg_particle_mass, avg_particle_mass);
       auto opacity_device = opacity_host.GetOnDevice();
-      params.Add("h.s_opacity_baseunits",
-                 GrayS(kappa * avg_particle_mass, avg_particle_mass));
+      params.Add("h.s_opacity_baseunits", opacity_host_baseunits);
       params.Add("h.s_opacity", opacity_host);
       params.Add("d.s_opacity", opacity_device);
     }


### PR DESCRIPTION
I noticed that when running outside of `scale_free` mode with radiation, the mean opacities are incorrect. This is because the mean opacity constructors expect an opacity *without* a unit conversion, e.g. `Gray`, whereas in phoebus outside of `scale_free` mode we pass in e.g. `NonCGSUnits<Gray>`.

My solution, to store both CGS and non-CGS host opacities, is a bit yucky. I wonder if this further motivates a `singularity-opac` refactor to deal also with the issue of too many variants brought up by @Yurlungur previously.

<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
