### PR TITLE
Fix radiation stress energy tensor in radiation moment geometric sources

### DIFF
--- a/scripts/python/plot_torus_3d.py
+++ b/scripts/python/plot_torus_3d.py
@@ -82,6 +82,7 @@ def plot_frame(ifname, fname, savefig, geomfile=None, rlim=40, coords='cartesian
   if ndim == 2:
     xblock = rblock*np.sin(thblock)
     yblock = rblock*np.cos(thblock)
+    zblock = None
   elif ndim == 3:
     xblock = rblock*np.sin(thblock)*np.cos(phiblock)
     yblock = rblock*np.cos(thblock)
@@ -113,7 +114,7 @@ def plot_frame(ifname, fname, savefig, geomfile=None, rlim=40, coords='cartesian
   density = dfile.Get("p.density", flatten=False)
   J = dfile.Get("r.p.J", flatten=False)
   print(f'density min: {density.min()} max: {density.max()}')
-  print(f'J min:       {J.min()} max: {J.max()}')
+  #print(f'J min:       {J.min()} max: {J.max()}')
 
   if ndim == 2:
     k = 0
@@ -149,7 +150,11 @@ def plot_frame(ifname, fname, savefig, geomfile=None, rlim=40, coords='cartesian
 
     ax = axes[0,2]
     Pg = dfile.GetPg()
-    Pm = np.clip(dfile.GetPm(), 1.e-20, 1.e20)
+    print(dfile.Params['fluid/mhd'])
+    if dfile.Params['fluid/mhd']:
+      Pm = np.clip(dfile.GetPm(), 1.e-20, 1.e20)
+    else:
+      Pm = 1.e-100
     lbeta = np.log10(Pg/Pm)
     for b in range(nblocks):
       im = ax.pcolormesh(xplot[b,:,:,k], yplot[b,:,:,k], lbeta[b,k,:,:].transpose(), vmin=-2, vmax=2,
@@ -245,7 +250,11 @@ def plot_frame(ifname, fname, savefig, geomfile=None, rlim=40, coords='cartesian
 
     ax = axes[1,1]
     Pg = dfile.GetPg()
-    Pm = np.clip(dfile.GetPm(), 1.e-20, 1.e20)
+    print(dfile.Params['fluid/mhd'])
+    if dfile.Params['fluid/mhd']:
+      Pm = np.clip(dfile.GetPm(), 1.e-20, 1.e20)
+    else:
+      Pm = 1.e-100
     lbeta = np.log10(Pg/Pm)
     for b in range(nblocks):
       im = ax.pcolormesh(xplot[b,:,:,k], yplot[b,:,:,k], lbeta[b,k,:,:].transpose(), vmin=-2, vmax=2,

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -582,22 +582,15 @@ TaskStatus CalculateFluidSourceTerms(MeshBlockData<Real> *rc,
           geom.ContravariantShift(CellLocation::Cent, k, j, i, shift);
           Real gcon0[4] = {-inv_alpha2, inv_alpha2 * shift[0], inv_alpha2 * shift[1],
                            inv_alpha2 * shift[2]};
-          for (int m = 0; m < ND; m++) {
-            for (int n = 0; n < ND; n++) {
-              Real gam0 = 0;
-              for (int r = 0; r < ND; r++) {
-                gam0 += gcon0[r] * gam[r][m][n];
-              }
-              TGam += Tmunu[m][n] * gam0;
-            }
+          SPACETIMELOOP2(m, n) {
+            Real gam0 = 0;
+            SPACETIMELOOP(r) { gam0 += gcon0[r] * gam[r][m][n]; }
+            TGam += Tmunu[m][n] * gam0;
           }
           Real Ta = 0.0;
           Real da[ND];
-          // Real *da = &gam[1][0][0];
           geom.GradLnAlpha(CellLocation::Cent, k, j, i, da);
-          for (int m = 0; m < ND; m++) {
-            Ta += Tmunu[m][0] * da[m];
-          }
+          SPACETIMELOOP(m) { Ta += Tmunu[m][0] * da[m]; }
           src(ceng, k, j, i) = gdet * alpha * (Ta - TGam);
 #else
                          SPACETIMELOOP2(mu, nu) {

--- a/src/radiation/moments.cpp
+++ b/src/radiation/moments.cpp
@@ -942,8 +942,14 @@ Real con_H4[4] = {0};
               v_src(iblock, idx_F_src(ispec, 2), k, j, i));
             printf("old srcs: %e %e %e %e\n", srcE_old,
               srcF_old(0), srcF_old(1), srcF_old(2));
-            exit(-1);
+         //   exit(-1);
           }
+
+          //v_src(iblock, idx_E_src(ispec), k, j, i) = sdetgam * srcE_old;
+          SPACELOOP(ii) {
+           // v_src(iblock, idx_F_src(ispec, ii), k, j, i) = sdetgam * srcF_old(ii);
+          }
+
 
 #if SET_FLUX_SRC_DIAGS
           v(iblock, idx_diag(ispec, 0), k, j, i) =

--- a/src/radiation/moments.cpp
+++ b/src/radiation/moments.cpp
@@ -916,18 +916,18 @@ Real con_H4[4] = {0};
 
           Real srcE_old = 0.;
           SPACETIMELOOP(mu) {
-            srcE_old += con_T[mu][0] * dlnalp[mu];
+            srcE_old += con_T_other[mu][0] * dlnalp[mu];
             SPACETIMELOOP(nu) {
               Real Gamma_udd = 0.;
               SPACETIMELOOP(lam) { Gamma_udd += con_g[0][lam] * Gamma[lam][nu][mu]; }
-              srcE_old -= con_T[mu][nu] * Gamma_udd;
+              srcE_old -= con_T_other[mu][nu] * Gamma_udd;
             }
           }
           srcE_old *= sdetgam * alp * alp;
 
           Vec srcF_old{0, 0, 0};
           SPACELOOP(ii) {
-            SPACETIMELOOP2(mu, nu) { srcF_old(ii) += con_T[mu][nu] * Gamma[mu][nu][ii + 1]; }
+            SPACETIMELOOP2(mu, nu) { srcF_old(ii) += con_T_other[mu][nu] * Gamma[mu][nu][ii + 1]; }
             srcF_old(ii) *= sdetgam * alp;
           }
 

--- a/src/radiation/moments.cpp
+++ b/src/radiation/moments.cpp
@@ -832,10 +832,11 @@ TaskStatus CalculateGeometricSourceImpl(T *rc, T *rc_src) {
         Real Gamma[ND][ND][ND];
         geom.GradLnAlpha(CellLocation::Cent, iblock, k, j, i, dlnalp);
         geom.ConnectionCoefficient(CellLocation::Cent, iblock, k, j, i, Gamma);
+        Real dg[ND][ND][ND];
+        geom.MetricDerivative(CellLocation::Cent, k, j, i, dg);
 
-        Real con_u[4];
-        con_u[0] = W / alp;
-        SPACELOOP(ii) { con_u[ii + 1] = W * con_v(ii) - con_beta(ii) / alp; }
+        Real con_n[4] = {1. / alp, -con_beta(0) / alp, -con_beta(1) / alp,
+                         -con_beta(2) / alp};
 
         for (int ispec = 0; ispec < nspec; ++ispec) {
           Real E = v(iblock, idx_E(ispec), k, j, i) / sdetgam;
@@ -846,54 +847,48 @@ TaskStatus CalculateGeometricSourceImpl(T *rc, T *rc_src) {
           Vec covH{{J * v(iblock, idx_H(ispec, 0), k, j, i),
                     J * v(iblock, idx_H(ispec, 1), k, j, i),
                     J * v(iblock, idx_H(ispec, 2), k, j, i)}};
+          Tens2 conTilPi;
+          if (iTilPi.IsValid()) {
+            SPACELOOP2(ii, jj) {
+              conTilPi(ii, jj) = v(iblock, iTilPi(ispec, ii, jj), k, j, i);
+            }
+          } else {
+            c.GetConTilPiFromPrim(J, covH, &conTilPi);
+          }
+          Tens2 conP;
+          c.getConPFromPrim(J, covH, conTilPi, &conP);
 
           Vec conF;
           g.raise3Vector(covF, &conF);
 
-          Real con_H4[4] = {0};
-          SPACELOOP2(ii, jj) { con_H4[ii + 1] += g.con_gamma(ii, jj) * covH(jj); }
-
-          Real conTilPi[4][4] = {0};
-          if (iTilPi.IsValid()) {
-            SPACELOOP2(ii, jj) {
-              conTilPi[ii + 1][jj + 1] = v(iblock, iTilPi(ispec, ii, jj), k, j, i);
-            }
-          } else {
-            Tens2 con_tilPi{0};
-            c.GetConTilPiFromPrim(J, covH, &con_tilPi);
-            SPACELOOP2(ii, jj) { conTilPi[ii + 1][jj + 1] = con_tilPi(ii, jj); }
-          }
-
-          Real con_T[4][4];
+          Real con_T[4][4] = {0};
           SPACETIMELOOP2(mu, nu) {
-            Real conh_munu = con_g[mu][nu] + con_u[mu] * con_u[nu];
-            con_T[mu][nu] = (con_u[mu] * con_u[nu] + conh_munu / 3.) * J;
-            con_T[mu][nu] += con_u[mu] * con_H4[nu] + con_u[nu] * con_H4[mu];
-            con_T[mu][nu] += J * conTilPi[mu][nu];
+            con_T[mu][nu] = con_n[mu] * con_n[nu] * E;
+            con_T[mu][nu] += conP(mu, nu);
           }
-
-          // TODO(BRR) add Pij contribution
-
-          Real srcE = 0.0;
           SPACETIMELOOP(mu) {
-            srcE += con_T[mu][0] * dlnalp[mu];
-            SPACETIMELOOP(nu) {
-              Real Gamma_udd = 0.;
-              SPACETIMELOOP(lam) { Gamma_udd += con_g[0][lam] * Gamma[lam][nu][mu]; }
-              srcE -= con_T[mu][nu] * Gamma_udd;
+            SPACELOOP(ii) {
+              con_T[mu][ii] += con_n[mu] * conF(ii);
+              con_T[ii][mu] += con_n[mu] * conF(ii);
             }
           }
-          srcE *= alp * alp;
 
-          Vec srcF{0, 0, 0};
-          SPACELOOP(ii) {
-            SPACETIMELOOP2(mu, nu) { srcF(ii) += con_T[mu][nu] * Gamma[mu][nu][ii + 1]; }
-            srcF(ii) *= alp;
+          Real TGam = 0.0;
+          SPACETIMELOOP2(m, n) {
+            Real gam0 = 0.;
+            SPACETIMELOOP(r) { gam0 += con_g[0][r] * Gamma[r][m][n]; }
+            TGam += con_T[m][n] * gam0;
           }
+          Real Ta = 0.0;
+          SPACETIMELOOP(m) { Ta += con_T[m][0] * dlnalp[m]; }
+          v_src(iblock, idx_E_src(ispec), k, j, i) = sdetgam * alp * (Ta - TGam);
 
-          v_src(iblock, idx_E_src(ispec), k, j, i) = sdetgam * srcE;
-          SPACELOOP(ii) {
-            v_src(iblock, idx_F_src(ispec, ii), k, j, i) = sdetgam * srcF(ii);
+          SPACELOOP(l) {
+            Real src_mom = 0.0;
+            SPACETIMELOOP2(m, n) {
+              src_mom += con_T[m][n] * (dg[n][l + 1][m] - Gamma[l + 1][n][m]);
+            }
+            v_src(iblock, idx_F_src(ispec, l), k, j, i) = sdetgam * src_mom;
           }
 
 #if SET_FLUX_SRC_DIAGS


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I was using an incorrect expression for the radiation stress energy tensor when evaluating the radiation moment geometric source terms (Basically I was treating the spatial projection of the four-vector `Halpha` as equivalent to `Halpha`). 

I also switched the expression for the geometric source terms in the radiation moments to match what we already use in the fluid (the two expressions should be equivalent but it would be weird to report different forms of the equations in e.g. a methods paper. I also anyway had a bug of an extra factor of `alpha` on one term in my old version).

I also switched some manual `for` loops in the fluid geometric sources to our `SPACETIMELOOP*` macros.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
- [ ] Check that the no-B-fields radiative Fishbone solution still looks good
- [ ] Check that the B-fields GRRMHD torus still looks good
