### PR TITLE
Add jet energy and momentum flux to history

### DIFF
--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -70,4 +70,59 @@ Real ReduceMassAccretionRate(MeshData<Real> *md) {
   return result;
 } // mass accretion
 
+Real ReduceJetPower(MeshData<Real> *md) {
+  const auto ib = md->GetBoundsI(IndexDomain::interior);
+  const auto jb = md->GetBoundsJ(IndexDomain::interior);
+  const auto kb = md->GetBoundsK(IndexDomain::interior);
+
+  auto pmb = md->GetParentPointer();
+  auto &pars = pmb->packages.Get("geometry")->AllParams();
+  const Real xh = pars.Get<Real>("xh");
+
+  namespace p = fluid_prim;
+  const std::vector<std::string> vars({p::density, p::bfield, p::velocity});
+
+  PackIndexMap imap;
+  auto pack = md->PackVariables(vars, imap);
+
+  const int prho = imap[p::density].first;
+  const int pvel_lo = imap[p::velocity].first;
+  const int pvel_hi = imap[p::velocity].second;
+  const int pb_lo = imap[p::bfield].first;
+  const int pb_hi = imap[p::bfield].second;
+
+  auto geom = Geometry::GetCoordinateSystem(md);
+
+  Real result = 0.0;
+  parthenon::par_reduce(
+      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Power", DevExecSpace(), 0,
+      pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
+        const auto &coords = pack.GetCoords(b);
+        const auto sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
+        if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
+          const Real dx1 = coords.Dx(X1DIR, k, j, i);
+          const Real dx2 = coords.Dx(X2DIR, k, j, i);
+          const Real dx3 = coords.Dx(X3DIR, k, j, i);
+
+          // interp to make sure we're getting the horizon correct
+          auto m =
+              (CalcEMFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i + 1) -
+               CalcEMFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i - 1)) /
+              (2.0 * dx1);
+          auto flux =
+              (CalcEMFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i) +
+               (xh - coords.x1v(i)) * m) *
+              dx2 * dx3;
+
+          lresult += flux;
+        } else {
+          lresult += 0.0;
+        }
+      },
+      result);
+  return result;
+
+} // JetPower
+
 } // namespace History

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -151,7 +151,6 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
   auto geom = Geometry::GetCoordinateSystem(md);
 
   const Real sigma_cutoff = pmb->packages.Get("fluid")->Param<Real>("sigma_cutoff");
-  std::printf("\n\n\n%f\n\n\n", sigma_cutoff);
 
   Real result = 0.0;
   parthenon::par_reduce(

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -95,8 +95,8 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
 
   Real result = 0.0;
   parthenon::par_reduce(
-      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Energy Flux", DevExecSpace(), 0,
-      pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Energy Flux",
+      DevExecSpace(), 0, pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
         const Real sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
@@ -106,10 +106,11 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
           const Real dx3 = coords.Dx(X3DIR, k, j, i);
 
           // interp to make sure we're getting the horizon correct
-          auto m =
-              (CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i + 1) -
-               CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i - 1)) /
-              (2.0 * dx1);
+          auto m = (CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j,
+                                     i + 1) -
+                    CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j,
+                                     i - 1)) /
+                   (2.0 * dx1);
           auto flux =
               (CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i) +
                (xh - coords.x1v(i)) * m) *
@@ -150,8 +151,8 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
 
   Real result = 0.0;
   parthenon::par_reduce(
-      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Momentum Flux", DevExecSpace(), 0,
-      pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Momentum Flux",
+      DevExecSpace(), 0, pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
         const Real sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
@@ -161,14 +162,15 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
           const Real dx3 = coords.Dx(X3DIR, k, j, i);
 
           // interp to make sure we're getting the horizon correct
-          auto m =
-              (CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i + 1) -
-               CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i - 1)) /
-              (2.0 * dx1);
-          auto flux =
-              (CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i) +
-               (xh - coords.x1v(i)) * m) *
-              dx2 * dx3;
+          auto m = (CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k,
+                                       j, i + 1) -
+                    CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k,
+                                       j, i - 1)) /
+                   (2.0 * dx1);
+          auto flux = (CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b,
+                                          k, j, i) +
+                       (xh - coords.x1v(i)) * m) *
+                      dx2 * dx3;
 
           lresult += flux;
         } else {

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -70,7 +70,7 @@ Real ReduceMassAccretionRate(MeshData<Real> *md) {
   return result;
 } // mass accretion
 
-Real ReduceJetPower(MeshData<Real> *md) {
+Real ReduceJetEnergyFlux(MeshData<Real> *md) {
   const auto ib = md->GetBoundsI(IndexDomain::interior);
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
   const auto kb = md->GetBoundsK(IndexDomain::interior);
@@ -95,11 +95,11 @@ Real ReduceJetPower(MeshData<Real> *md) {
 
   Real result = 0.0;
   parthenon::par_reduce(
-      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Power", DevExecSpace(), 0,
+      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Energy Flux", DevExecSpace(), 0,
       pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
-        const auto sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
+        const Real sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
         if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
           const Real dx1 = coords.Dx(X1DIR, k, j, i);
           const Real dx2 = coords.Dx(X2DIR, k, j, i);
@@ -107,11 +107,11 @@ Real ReduceJetPower(MeshData<Real> *md) {
 
           // interp to make sure we're getting the horizon correct
           auto m =
-              (CalcEMFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i + 1) -
-               CalcEMFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i - 1)) /
+              (CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i + 1) -
+               CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i - 1)) /
               (2.0 * dx1);
           auto flux =
-              (CalcEMFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i) +
+              (CalcEMEnergyFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i) +
                (xh - coords.x1v(i)) * m) *
               dx2 * dx3;
 
@@ -123,6 +123,61 @@ Real ReduceJetPower(MeshData<Real> *md) {
       result);
   return result;
 
-} // JetPower
+} // JetEnergyFlux
+
+Real ReduceJetMomentumFlux(MeshData<Real> *md) {
+  const auto ib = md->GetBoundsI(IndexDomain::interior);
+  const auto jb = md->GetBoundsJ(IndexDomain::interior);
+  const auto kb = md->GetBoundsK(IndexDomain::interior);
+
+  auto pmb = md->GetParentPointer();
+  auto &pars = pmb->packages.Get("geometry")->AllParams();
+  const Real xh = pars.Get<Real>("xh");
+
+  namespace p = fluid_prim;
+  const std::vector<std::string> vars({p::density, p::bfield, p::velocity});
+
+  PackIndexMap imap;
+  auto pack = md->PackVariables(vars, imap);
+
+  const int prho = imap[p::density].first;
+  const int pvel_lo = imap[p::velocity].first;
+  const int pvel_hi = imap[p::velocity].second;
+  const int pb_lo = imap[p::bfield].first;
+  const int pb_hi = imap[p::bfield].second;
+
+  auto geom = Geometry::GetCoordinateSystem(md);
+
+  Real result = 0.0;
+  parthenon::par_reduce(
+      parthenon::LoopPatternMDRange(), "Phoebus History for Jet Momentum Flux", DevExecSpace(), 0,
+      pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
+        const auto &coords = pack.GetCoords(b);
+        const Real sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
+        if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
+          const Real dx1 = coords.Dx(X1DIR, k, j, i);
+          const Real dx2 = coords.Dx(X2DIR, k, j, i);
+          const Real dx3 = coords.Dx(X3DIR, k, j, i);
+
+          // interp to make sure we're getting the horizon correct
+          auto m =
+              (CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i + 1) -
+               CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i - 1)) /
+              (2.0 * dx1);
+          auto flux =
+              (CalcEMMomentumFlux(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi, b, k, j, i) +
+               (xh - coords.x1v(i)) * m) *
+              dx2 * dx3;
+
+          lresult += flux;
+        } else {
+          lresult += 0.0;
+        }
+      },
+      result);
+  return result;
+
+} // ReduceJetMomentumFlux
 
 } // namespace History

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -91,6 +91,8 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
 
   auto geom = Geometry::GetCoordinateSystem(md);
 
+  const Real sigma_cutoff = pmb->packages.Get("fluid")->Param<Real>("sigma_cutoff");
+
   Real result = 0.0;
   parthenon::par_reduce(
       parthenon::LoopPatternMDRange(), "Phoebus History for Jet Energy Flux",
@@ -99,7 +101,7 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
         const auto &coords = pack.GetCoords(b);
         const Real sigma = CalcMagnetization(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi,
                                              prho, b, k, j, i);
-        if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
+        if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > sigma_cutoff) {
           const Real dx1 = coords.Dx(X1DIR, k, j, i);
           const Real dx2 = coords.Dx(X2DIR, k, j, i);
           const Real dx3 = coords.Dx(X3DIR, k, j, i);
@@ -148,6 +150,9 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
 
   auto geom = Geometry::GetCoordinateSystem(md);
 
+  const Real sigma_cutoff = pmb->packages.Get("fluid")->Param<Real>("sigma_cutoff");
+  std::printf("\n\n\n%f\n\n\n", sigma_cutoff);
+
   Real result = 0.0;
   parthenon::par_reduce(
       parthenon::LoopPatternMDRange(), "Phoebus History for Jet Momentum Flux",
@@ -156,7 +161,7 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
         const auto &coords = pack.GetCoords(b);
         const Real sigma = CalcMagnetization(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi,
                                              prho, b, k, j, i);
-        if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
+        if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > sigma_cutoff) {
           const Real dx1 = coords.Dx(X1DIR, k, j, i);
           const Real dx2 = coords.Dx(X2DIR, k, j, i);
           const Real dx3 = coords.Dx(X3DIR, k, j, i);

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -97,7 +97,8 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
       DevExecSpace(), 0, pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
-        const Real sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
+        const Real sigma = CalcMagnetization(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi,
+                                             prho, b, k, j, i);
         if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
           const Real dx1 = coords.Dx(X1DIR, k, j, i);
           const Real dx2 = coords.Dx(X2DIR, k, j, i);
@@ -153,7 +154,8 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
       DevExecSpace(), 0, pack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
-        const Real sigma = CalcMagnetization(pack, geom, pb_lo, pb_hi, prho, b, k, j, i);
+        const Real sigma = CalcMagnetization(pack, geom, pvel_lo, pvel_hi, pb_lo, pb_hi,
+                                             prho, b, k, j, i);
         if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1) && sigma > 1.0) {
           const Real dx1 = coords.Dx(X1DIR, k, j, i);
           const Real dx2 = coords.Dx(X2DIR, k, j, i);

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -47,8 +47,6 @@ Real ReduceMassAccretionRate(MeshData<Real> *md) {
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
         if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1)) {
-          const Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
-
           const Real dx1 = coords.Dx(X1DIR, k, j, i);
           const Real dx2 = coords.Dx(X2DIR, k, j, i);
           const Real dx3 = coords.Dx(X3DIR, k, j, i);
@@ -61,7 +59,7 @@ Real ReduceMassAccretionRate(MeshData<Real> *md) {
                        (xh - coords.x1v(i)) * m) *
                       dx2 * dx3;
 
-          lresult += -flux;
+          lresult += flux;
         } else {
           lresult += 0.0;
         }

--- a/src/analysis/history.hpp
+++ b/src/analysis/history.hpp
@@ -38,7 +38,8 @@ using namespace parthenon::package::prelude;
 namespace History {
 
 Real ReduceMassAccretionRate(MeshData<Real> *md);
-Real ReduceJetPower(MeshData<Real> *md);
+Real ReduceJetEnergyFlux(MeshData<Real> *md);
+Real ReduceJetMomentumFlux(MeshData<Real> *md);
 
 template <typename Reducer_t>
 Real ReduceOneVar(MeshData<Real> *md, const std::string &varname, int idx = 0) {

--- a/src/analysis/history.hpp
+++ b/src/analysis/history.hpp
@@ -38,6 +38,7 @@ using namespace parthenon::package::prelude;
 namespace History {
 
 Real ReduceMassAccretionRate(MeshData<Real> *md);
+Real ReduceJetPower(MeshData<Real> *md);
 
 template <typename Reducer_t>
 Real ReduceOneVar(MeshData<Real> *md, const std::string &varname, int idx = 0) {

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -51,6 +51,23 @@ KOKKOS_INLINE_FUNCTION Real CalcMassFlux(Pack &pack, Geometry &geom, const int p
   return lapse * gdet * pack(b, prho, k, j, i) * ucon;
 }
 
+template <typename Pack, typename Geometry>
+KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom, const int pb_lo,
+                                              const int pb_hi, const int prho,
+                                              const int b, const int k, const int j,
+                                              const int i) {
+  Real gcov[4][4];
+  geom.SpacetimeMetric(CellLocation::Cent, k, j, i, gcov);
+  const Real Bp[] = {pack(b, pb_lo, k, j, i), pack(b, pb_lo + 1, k, j, i),
+                     pack(b, pb_hi, k, j, i)};
+  const Real rho = pack(b, prho, k, j, i);
+
+  Real Bsq = 0;
+  SPACELOOP2(m, n) { Bsq += gcov[m][n] * Bp[m] * Bp[n]; }
+
+  return Bsq / rho;
+}
+
 } // namespace History
 
 #endif // ANALYSIS_HISTORY_UTILS_HPP_

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -50,7 +50,7 @@ KOKKOS_INLINE_FUNCTION Real CalcMassFlux(Pack &pack, Geometry &geom, const int p
   const Real W = phoebus::GetLorentzFactor(vel, gcov4);
   const Real ucon = vel[0] - shift[0] * W / lapse;
 
-  return lapse * gdet * pack(b, prho, k, j, i) * ucon;
+  return -lapse * gdet * pack(b, prho, k, j, i) * ucon;
 }
 
 template <typename Pack, typename Geometry>

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -74,10 +74,11 @@ KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom, const 
 }
 
 template <typename Pack, typename Geometry>
-KOKKOS_INLINE_FUNCTION Real CalcEMEnergyFlux(Pack &pack, Geometry &geom, const int pvel_lo,
-                                         const int pvel_hi, const int pb_lo,
-                                         const int pb_hi, const int b, const int k,
-                                         const int j, const int i) {
+KOKKOS_INLINE_FUNCTION Real CalcEMEnergyFlux(Pack &pack, Geometry &geom,
+                                             const int pvel_lo, const int pvel_hi,
+                                             const int pb_lo, const int pb_hi,
+                                             const int b, const int k, const int j,
+                                             const int i) {
   Real gam[3][3];
   geom.Metric(CellLocation::Cent, k, j, i, gam);
   Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
@@ -111,14 +112,15 @@ KOKKOS_INLINE_FUNCTION Real CalcEMEnergyFlux(Pack &pack, Geometry &geom, const i
   // energy flux of EM stress energy tensor
   const Real T_EM_01 = bsq * ucon0 * ucov1 - b0 * bcov1;
 
-  return + T_EM_01 * lapse * gdet;
+  return +T_EM_01 * lapse * gdet;
 } // energy flux
 
 template <typename Pack, typename Geometry>
-KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom, const int pvel_lo,
-                                         const int pvel_hi, const int pb_lo,
-                                         const int pb_hi, const int b, const int k,
-                                         const int j, const int i) {
+KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom,
+                                               const int pvel_lo, const int pvel_hi,
+                                               const int pb_lo, const int pb_hi,
+                                               const int b, const int k, const int j,
+                                               const int i) {
   Real gam[3][3];
   geom.Metric(CellLocation::Cent, k, j, i, gam);
   Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
@@ -155,8 +157,8 @@ KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom, const
   // momentum flux part of EM stress energy tensor
   const Real T_EM_11 = bsq * ucon1 * ucov1 - bcon1 * bcov1 + 0.5 * bsq;
 
-  return - T_EM_11 * lapse * gdet;
-} //momentum flux
+  return -T_EM_11 * lapse * gdet;
+} // momentum flux
 
 } // namespace History
 

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -20,6 +20,7 @@
 #include "geometry/geometry.hpp"
 #include "geometry/geometry_utils.hpp"
 #include "phoebus_utils/relativity_utils.hpp"
+#include "phoebus_utils/robust.hpp"
 #include "phoebus_utils/variables.hpp"
 #include <kokkos_abstraction.hpp>
 #include <parthenon/package.hpp>
@@ -57,8 +58,8 @@ KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom, const 
                                               const int pb_hi, const int prho,
                                               const int b, const int k, const int j,
                                               const int i) {
-  Real gcov[4][4];
-  geom.SpacetimeMetric(CellLocation::Cent, k, j, i, gcov);
+  Real gam[3][3];
+  geom.Metric(CellLocation::Cent, k, j, i, gam);
   const Real Bp[] = {pack(b, pb_lo, k, j, i), pack(b, pb_lo + 1, k, j, i),
                      pack(b, pb_hi, k, j, i)};
   const Real rho = pack(b, prho, k, j, i);
@@ -66,17 +67,17 @@ KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom, const 
   Real Bsq = 0;
   for (int m = 0; m < 3; m++)
     for (int n = 0; n < 3; n++) {
-      Bsq += gcov[m][n] * Bp[m] * Bp[n];
+      Bsq += gam[m][n] * Bp[m] * Bp[n];
     }
 
   return Bsq / rho;
 }
 
 template <typename Pack, typename Geometry>
-KOKKOS_INLINE_FUNCTION Real CalcEMFlux(Pack &pack, Geometry &geom, const int pvel_lo,
-                                       const int pvel_hi, const int pb_lo,
-                                       const int pb_hi, const int b, const int k,
-                                       const int j, const int i) {
+KOKKOS_INLINE_FUNCTION Real CalcEMEnergyFlux(Pack &pack, Geometry &geom, const int pvel_lo,
+                                         const int pvel_hi, const int pb_lo,
+                                         const int pb_hi, const int b, const int k,
+                                         const int j, const int i) {
   Real gam[3][3];
   geom.Metric(CellLocation::Cent, k, j, i, gam);
   Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
@@ -97,21 +98,65 @@ KOKKOS_INLINE_FUNCTION Real CalcEMFlux(Pack &pack, Geometry &geom, const int pve
       Bsq += gam[m][n] * Bp[m] * Bp[n];
       vcov[m] += gam[m][n] * vcon[n];
       Bcov[m] += gam[m][n] * Bp[n];
-      Bdotv += gam[m][n] * Bp[m] * vcon[n];
+      Bdotv += gam[m][n] * Bp[m] * robust::ratio(vcon[n], W);
     }
 
   const Real b0 = Bdotv * W / lapse;
   const Real ucon0 = W / lapse;
-  const Real ucov1 = vcov[1];
-  const Real bcov1 = (Bcov[1] + lapse * b0 * ucov1) / W;
+  const Real ucov1 = vcov[0];
+  const Real bcov1 = robust::ratio((Bcov[0] + lapse * b0 * ucov1), W);
 
   const Real bsq = phoebus::GetMagneticFieldSquared(gam, vcon, Bp, W);
 
-  // time-radius part of EM stress energy tensor
+  // energy flux of EM stress energy tensor
   const Real T_EM_01 = bsq * ucon0 * ucov1 - b0 * bcov1;
 
-  return T_EM_01 * lapse * gdet;
-}
+  return + T_EM_01 * lapse * gdet;
+} // energy flux
+
+template <typename Pack, typename Geometry>
+KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom, const int pvel_lo,
+                                         const int pvel_hi, const int pb_lo,
+                                         const int pb_hi, const int b, const int k,
+                                         const int j, const int i) {
+  Real gam[3][3];
+  geom.Metric(CellLocation::Cent, k, j, i, gam);
+  Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
+  Real lapse = geom.Lapse(CellLocation::Cent, k, j, i);
+  Real shift[3];
+  geom.ContravariantShift(CellLocation::Cent, k, j, i, shift);
+
+  const Real vcon[] = {pack(b, pvel_lo, k, j, i), pack(b, pvel_lo + 1, k, j, i),
+                       pack(b, pvel_hi, k, j, i)};
+  const Real Bp[] = {pack(b, pb_lo, k, j, i), pack(b, pb_lo + 1, k, j, i),
+                     pack(b, pb_hi, k, j, i)};
+  const Real W = phoebus::GetLorentzFactor(vcon, gam);
+
+  Real Bsq = 0.0;
+  Real Bdotv = 0.0;
+  Real vcov[3] = {0};
+  Real Bcov[3] = {0};
+  for (int m = 0; m < 3; m++)
+    for (int n = 0; n < 3; n++) {
+      Bsq += gam[m][n] * Bp[m] * Bp[n];
+      vcov[m] += gam[m][n] * vcon[n];
+      Bcov[m] += gam[m][n] * Bp[n];
+      Bdotv += gam[m][n] * Bp[m] * robust::ratio(vcon[n], W);
+    }
+
+  const Real b0 = Bdotv * W / lapse;
+  const Real ucon1 = vcon[0] - shift[0] * W / lapse;
+  const Real ucov1 = vcov[0];
+  const Real bcon1 = robust::ratio((Bp[0] + lapse * b0 * ucon1), W);
+  const Real bcov1 = robust::ratio((Bcov[0] + lapse * b0 * ucov1), W);
+
+  const Real bsq = phoebus::GetMagneticFieldSquared(gam, vcon, Bp, W);
+
+  // momentum flux part of EM stress energy tensor
+  const Real T_EM_11 = bsq * ucon1 * ucov1 - bcon1 * bcov1 + 0.5 * bsq;
+
+  return - T_EM_11 * lapse * gdet;
+} //momentum flux
 
 } // namespace History
 

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -92,15 +92,9 @@ KOKKOS_INLINE_FUNCTION Real CalcEMEnergyFlux(Pack &pack, Geometry &geom,
                      pack(b, pb_hi, k, j, i)};
   const Real W = phoebus::GetLorentzFactor(vcon, gam);
 
-  Real Bsq = 0.0;
   Real Bdotv = 0.0;
-  Real vcov[3] = {0};
-  Real Bcov[3] = {0};
   for (int m = 0; m < 3; m++)
     for (int n = 0; n < 3; n++) {
-      Bsq += gam[m][n] * Bp[m] * Bp[n];
-      vcov[m] += gam[m][n] * vcon[n];
-      Bcov[m] += gam[m][n] * Bp[n];
       Bdotv += gam[m][n] * Bp[m] * robust::ratio(vcon[n], W);
     }
 
@@ -136,13 +130,11 @@ KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom,
                      pack(b, pb_hi, k, j, i)};
   const Real W = phoebus::GetLorentzFactor(vcon, gam);
 
-  Real Bsq = 0.0;
   Real Bdotv = 0.0;
   Real vcov[3] = {0};
   Real Bcov[3] = {0};
   for (int m = 0; m < 3; m++)
     for (int n = 0; n < 3; n++) {
-      Bsq += gam[m][n] * Bp[m] * Bp[n];
       vcov[m] += gam[m][n] * vcon[n];
       Bcov[m] += gam[m][n] * Bp[n];
       Bdotv += gam[m][n] * Bp[m] * robust::ratio(vcon[n], W);

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -54,23 +54,23 @@ KOKKOS_INLINE_FUNCTION Real CalcMassFlux(Pack &pack, Geometry &geom, const int p
 }
 
 template <typename Pack, typename Geometry>
-KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom, const int pb_lo,
-                                              const int pb_hi, const int prho,
-                                              const int b, const int k, const int j,
-                                              const int i) {
+KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom,
+                                              const int pvel_lo, const int pvel_hi,
+                                              const int pb_lo, const int pb_hi,
+                                              const int prho, const int b, const int k,
+                                              const int j, const int i) {
   Real gam[3][3];
   geom.Metric(CellLocation::Cent, k, j, i, gam);
   const Real Bp[] = {pack(b, pb_lo, k, j, i), pack(b, pb_lo + 1, k, j, i),
                      pack(b, pb_hi, k, j, i)};
+  const Real vcon[] = {pack(b, pvel_lo, k, j, i), pack(b, pvel_lo + 1, k, j, i),
+                       pack(b, pvel_hi, k, j, i)};
   const Real rho = pack(b, prho, k, j, i);
+  const Real W = phoebus::GetLorentzFactor(vcon, gam);
 
-  Real Bsq = 0;
-  for (int m = 0; m < 3; m++)
-    for (int n = 0; n < 3; n++) {
-      Bsq += gam[m][n] * Bp[m] * Bp[n];
-    }
+  const Real bsq = phoebus::GetMagneticFieldSquared(gam, vcon, Bp, W);
 
-  return Bsq / rho;
+  return bsq / rho;
 }
 
 template <typename Pack, typename Geometry>

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -26,6 +26,7 @@
 #include <utils/error_checking.hpp>
 
 using namespace parthenon::package::prelude;
+using namespace Geometry;
 
 namespace History {
 
@@ -63,7 +64,10 @@ KOKKOS_INLINE_FUNCTION Real CalcMagnetization(Pack &pack, Geometry &geom, const 
   const Real rho = pack(b, prho, k, j, i);
 
   Real Bsq = 0;
-  SPACELOOP2(m, n) { Bsq += gcov[m][n] * Bp[m] * Bp[n]; }
+  for (int m = 0; m < 3; m++)
+    for (int n = 0; n < 3; n++) {
+      Bsq += gcov[m][n] * Bp[m] * Bp[n];
+    }
 
   return Bsq / rho;
 }
@@ -88,12 +92,13 @@ KOKKOS_INLINE_FUNCTION Real CalcEMFlux(Pack &pack, Geometry &geom, const int pve
   Real Bdotv = 0.0;
   Real vcov[3] = {0};
   Real Bcov[3] = {0};
-  SPACELOOP2(m, n) {
-    Bsq += gam[m][n] * Bp[m] * Bp[n];
-    vcov[m] += gam[m][n] * vcon[n];
-    Bcov[m] += gam[m][n] * Bp[n];
-    Bdotv += gam[m][n] * Bp[m] * vcon[n];
-  }
+  for (int m = 0; m < 3; m++)
+    for (int n = 0; n < 3; n++) {
+      Bsq += gam[m][n] * Bp[m] * Bp[n];
+      vcov[m] += gam[m][n] * vcon[n];
+      Bcov[m] += gam[m][n] * Bp[n];
+      Bdotv += gam[m][n] * Bp[m] * vcon[n];
+    }
 
   const Real b0 = Bdotv * W / lapse;
   const Real ucon0 = W / lapse;

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -130,6 +130,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   bool mhd = pin->GetOrAddBoolean("fluid", "mhd", false);
   params.Add("mhd", mhd);
 
+  Real sigma_cutoff = pin->GetOrAddReal("fluid", "sigma_cutoff", 1.0);
+  params.Add("sigma_cutoff", sigma_cutoff);
+
   Metadata m;
   std::vector<int> three_vec(1, 3);
 

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -56,9 +56,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   const bool do_hydro = pin->GetBoolean("physics", "hydro");
   if (params.hasKey("xh") && do_hydro) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
-    using History::ReduceMassAccretionRate;
     using History::ReduceJetEnergyFlux;
     using History::ReduceJetMomentumFlux;
+    using History::ReduceMassAccretionRate;
     using parthenon::HistoryOutputVar;
     parthenon::HstVar_list hst_vars = {};
 
@@ -75,8 +75,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     };
 
     hst_vars.emplace_back(HistoryOutputVar(HstSum, ReduceAccretionRate, "mdot"));
-    hst_vars.emplace_back(HistoryOutputVar(HstSum, ComputeJetEnergyFlux, "jet_energy_flux"));
-    hst_vars.emplace_back(HistoryOutputVar(HstSum, ComputeJetMomentumFlux, "jet_momentum_flux"));
+    hst_vars.emplace_back(
+        HistoryOutputVar(HstSum, ComputeJetEnergyFlux, "jet_energy_flux"));
+    hst_vars.emplace_back(
+        HistoryOutputVar(HstSum, ComputeJetMomentumFlux, "jet_momentum_flux"));
     params.Add(parthenon::hist_param_key, hst_vars);
   }
 

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -57,6 +57,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   if (params.hasKey("xh") && do_hydro) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceMassAccretionRate;
+    using History::ReduceJetEnergyFlux;
+    using History::ReduceJetMomentumFlux;
     using parthenon::HistoryOutputVar;
     parthenon::HstVar_list hst_vars = {};
 
@@ -64,7 +66,17 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       return ReduceMassAccretionRate(md);
     };
 
+    auto ComputeJetEnergyFlux = [](MeshData<Real> *md) {
+      return ReduceJetEnergyFlux(md);
+    };
+
+    auto ComputeJetMomentumFlux = [](MeshData<Real> *md) {
+      return ReduceJetMomentumFlux(md);
+    };
+
     hst_vars.emplace_back(HistoryOutputVar(HstSum, ReduceAccretionRate, "mdot"));
+    hst_vars.emplace_back(HistoryOutputVar(HstSum, ComputeJetEnergyFlux, "jet_energy_flux"));
+    hst_vars.emplace_back(HistoryOutputVar(HstSum, ComputeJetMomentumFlux, "jet_momentum_flux"));
     params.Add(parthenon::hist_param_key, hst_vars);
   }
 


### PR DESCRIPTION
This PR adds the jet EM energy and momentum flux to the history output. Below, energy flux (first) and momentum flux (second). There are a couple of minor tweaks to the mass accretion rate, removal of an unused variable, etc.
![image](https://user-images.githubusercontent.com/39746406/203144610-7782c684-b982-40e7-aa3d-726c375b097c.png)
![image](https://user-images.githubusercontent.com/39746406/203144650-9c7b1607-9dac-4702-a847-478b8aeff3e3.png)


- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
