### PR TITLE
Add magnetic flux Phi to history

### DIFF
--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -212,16 +212,17 @@ Real ReduceMagneticFluxPhi(MeshData<Real> *md) {
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &lresult) {
         const auto &coords = pack.GetCoords(b);
         if (coords.x1f(i) <= xh && xh < coords.x1f(i + 1)) {
-          const Real dx1 = coords.Dx(X1DIR, k, j, i+1);
-          const Real dx2 = coords.Dx(X2DIR, k, j, i+1);
-          const Real dx3 = coords.Dx(X3DIR, k, j, i+1);
+          const Real dx1 = coords.Dx(X1DIR, k, j, i + 1);
+          const Real dx2 = coords.Dx(X2DIR, k, j, i + 1);
+          const Real dx3 = coords.Dx(X3DIR, k, j, i + 1);
 
           // interp to make sure we're getting the horizon correct
-          auto m = (CalcMagneticFluxPhi(pack, geom, cb_lo, b, k, j, i + 1 +1) -
-                    CalcMagneticFluxPhi(pack, geom, cb_lo, b, k, j, i - 1 +1)) /
+          auto m = (CalcMagneticFluxPhi(pack, geom, cb_lo, b, k, j, i + 1 + 1) -
+                    CalcMagneticFluxPhi(pack, geom, cb_lo, b, k, j, i - 1 + 1)) /
                    (2.0 * dx1);
-          auto flux = (CalcMagneticFluxPhi(pack, geom, cb_lo, b, k, j, i+1) +
-                       (xh - coords.x1v(i+1)) * m) * dx2 * dx3;
+          auto flux = (CalcMagneticFluxPhi(pack, geom, cb_lo, b, k, j, i + 1) +
+                       (xh - coords.x1v(i + 1)) * m) *
+                      dx2 * dx3;
 
           lresult += flux;
         } else {

--- a/src/analysis/history.hpp
+++ b/src/analysis/history.hpp
@@ -40,6 +40,7 @@ namespace History {
 Real ReduceMassAccretionRate(MeshData<Real> *md);
 Real ReduceJetEnergyFlux(MeshData<Real> *md);
 Real ReduceJetMomentumFlux(MeshData<Real> *md);
+Real ReduceMagneticFluxPhi(MeshData<Real> *md);
 
 template <typename Reducer_t>
 Real ReduceOneVar(MeshData<Real> *md, const std::string &varname, int idx = 0) {

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -156,8 +156,8 @@ KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom,
 
 template <typename Pack, typename Geometry>
 KOKKOS_INLINE_FUNCTION Real CalcMagneticFluxPhi(Pack &pack, Geometry &geom,
-                                                const int cb_lo, const int b,
-                                                const int k, const int j, const int i) {
+                                                const int cb_lo, const int b, const int k,
+                                                const int j, const int i) {
   Real lapse = geom.Lapse(CellLocation::Cent, k, j, i);
 
   // \int B^r sqrt(-gdet) := (detgam B^r) * lapse

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -156,20 +156,12 @@ KOKKOS_INLINE_FUNCTION Real CalcEMMomentumFlux(Pack &pack, Geometry &geom,
 
 template <typename Pack, typename Geometry>
 KOKKOS_INLINE_FUNCTION Real CalcMagneticFluxPhi(Pack &pack, Geometry &geom,
-                                                const int pvel_lo, const int pvel_hi,
-                                                const int pb_lo, const int pb_hi,
-                                                const int b, const int k, const int j,
-                                                const int i) {
-  Real gam[3][3];
-  geom.Metric(CellLocation::Cent, k, j, i, gam);
-  Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
+                                                const int cb_lo, const int b,
+                                                const int k, const int j, const int i) {
   Real lapse = geom.Lapse(CellLocation::Cent, k, j, i);
 
-  const Real Bp[] = {pack(b, pb_lo, k, j, i), pack(b, pb_lo + 1, k, j, i),
-                     pack(b, pb_hi, k, j, i)};
-
-  // \int B^r sqrt(-gdet) := B^r / alpha * (alpha * detgamma)
-  return std::abs(Bp[0]) * gdet;
+  // \int B^r sqrt(-gdet) := (detgam B^r) * lapse
+  return std::abs(pack(b, cb_lo, k, j, i)) * lapse;
 } // Phi
 
 } // namespace History

--- a/src/analysis/history_utils.hpp
+++ b/src/analysis/history_utils.hpp
@@ -164,26 +164,12 @@ KOKKOS_INLINE_FUNCTION Real CalcMagneticFluxPhi(Pack &pack, Geometry &geom,
   geom.Metric(CellLocation::Cent, k, j, i, gam);
   Real gdet = geom.DetGamma(CellLocation::Cent, k, j, i);
   Real lapse = geom.Lapse(CellLocation::Cent, k, j, i);
-  Real shift[3];
-  geom.ContravariantShift(CellLocation::Cent, k, j, i, shift);
 
-  const Real vcon[] = {pack(b, pvel_lo, k, j, i), pack(b, pvel_lo + 1, k, j, i),
-                       pack(b, pvel_hi, k, j, i)};
   const Real Bp[] = {pack(b, pb_lo, k, j, i), pack(b, pb_lo + 1, k, j, i),
                      pack(b, pb_hi, k, j, i)};
-  const Real W = phoebus::GetLorentzFactor(vcon, gam);
 
-  Real Bdotv = 0.0;
-  for (int m = 0; m < 3; m++)
-    for (int n = 0; n < 3; n++) {
-      Bdotv += gam[m][n] * Bp[m] * robust::ratio(vcon[n], W);
-    }
-  const Real ucon0 = W / lapse;
-  const Real ucon1 = vcon[0] - shift[0] * W / lapse;
-  const Real b0 = Bdotv * W / lapse;
-  const Real bcon1 = robust::ratio((Bp[0] + lapse * b0 * ucon1), W);
-
-  return std::abs(bcon1 * ucon0 - b0 * ucon1) * lapse * gdet;
+  // \int B^r sqrt(-gdet) := B^r / alpha * (alpha * detgamma)
+  return std::abs(Bp[0]) * gdet;
 } // Phi
 
 } // namespace History

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;
     using History::ReduceJetMomentumFlux;
+    using History::ReduceMagneticFluxPhi;
     using History::ReduceMassAccretionRate;
     using parthenon::HistoryOutputVar;
     parthenon::HstVar_list hst_vars = {};
@@ -81,11 +82,17 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       return ReduceJetMomentumFlux(md);
     };
 
+    auto ComputeMagneticFluxPhi = [](MeshData<Real> *md) {
+      return ReduceMagneticFluxPhi(md);
+    };
+
     hst_vars.emplace_back(HistoryOutputVar(HstSum, ReduceAccretionRate, "mdot"));
     hst_vars.emplace_back(
         HistoryOutputVar(HstSum, ComputeJetEnergyFlux, "jet_energy_flux"));
     hst_vars.emplace_back(
         HistoryOutputVar(HstSum, ComputeJetMomentumFlux, "jet_momentum_flux"));
+    hst_vars.emplace_back(
+        HistoryOutputVar(HstSum, ComputeMagneticFluxPhi, "magnetic_Phi"));
     params.Add(parthenon::hist_param_key, hst_vars);
   }
 


### PR DESCRIPTION
Here I add the magnetic flux Phi to the output. Below shows the unnormalized and normalized magnetic flux. The scales seem okay but it's hard for me to compare directly to the plots in the EHT code comparison paper because they do 3D and the dynamics are a bit different. Thoughts?
![image](https://user-images.githubusercontent.com/39746406/204935365-c79eea26-6efa-4324-93f8-7b8d87c27111.png)
![image](https://user-images.githubusercontent.com/39746406/204935410-4ae15e27-ecf5-4f33-ab08-da5da3f6c582.png)


- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
