### PR TITLE
Fix: update restart logic in main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
   pman.ParthenonInitPackagesAndMesh();
 
   // call post-initialization
-  if (pman.IsRestart()) {
+  if (!pman.IsRestart()) {
     phoebus::PostInitializationModifier(pman.pinput.get(), pman.pmesh.get());
   }
 


### PR DESCRIPTION
There was a logic issue / missing `!` in `main.cpp` that prevented the post initialization modifications from being applied on the first run. Should be the source of the weird Phi behavior seen in  #151 as well.



- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ x] Format your changes by calling `scripts/bash/format.sh`.
- [x ] Explain what you did.
