### PR TITLE
Reduce imported complexity from singularity-eos

### DIFF
--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -17,12 +17,12 @@
 
 #include <bvals/bvals_interfaces.hpp>
 #include <defs.hpp>
-#include <singularity-eos/eos/eos.hpp>
 
 #include "fluid/con2prim_robust.hpp"
 #include "fluid/fluid.hpp"
 #include "fluid/prim2con.hpp"
 #include "geometry/geometry.hpp"
+#include "microphysics/eos_phoebus/eos_phoebus.hpp"
 #include "phoebus_utils/programming_utils.hpp"
 #include "phoebus_utils/relativity_utils.hpp"
 #include "phoebus_utils/robust.hpp"
@@ -38,7 +38,8 @@ using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using singularity::RadiationType;
+using Microphysics::RadiationType;
+using Microphysics::EOS::EOS;
 
 namespace fixup {
 
@@ -312,7 +313,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
   const int num_species = enable_rad_floors ? rad_pkg->Param<int>("num_species") : 0;
 
-  auto eos = eos_pkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eos_pkg->Param<EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   auto bounds = fix_pkg->Param<Bounds>("bounds");
 

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -32,14 +32,14 @@
 #include "radiation/closure_mocmc.hpp"
 #include "radiation/radiation.hpp"
 
+using Microphysics::RadiationType;
+using Microphysics::EOS::EOS;
 using radiation::ClosureEquation;
 using radiation::ClosureSettings;
 using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using Microphysics::RadiationType;
-using Microphysics::EOS::EOS;
 
 namespace fixup {
 

--- a/src/fixup/fixup_c2p.cpp
+++ b/src/fixup/fixup_c2p.cpp
@@ -17,12 +17,12 @@
 
 #include <bvals/bvals_interfaces.hpp>
 #include <defs.hpp>
-#include <singularity-eos/eos/eos.hpp>
 
 #include "fluid/con2prim_robust.hpp"
 #include "fluid/prim2con.hpp"
 #include "geometry/geometry.hpp"
 #include "geometry/tetrads.hpp"
+#include "microphysics/eos_phoebus/eos_phoebus.hpp"
 #include "phoebus_utils/programming_utils.hpp"
 #include "phoebus_utils/relativity_utils.hpp"
 #include "phoebus_utils/robust.hpp"
@@ -38,7 +38,6 @@ using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using singularity::RadiationType;
 
 namespace fixup {
 
@@ -153,7 +152,7 @@ TaskStatus ConservedToPrimitiveFixupImpl(T *rc) {
 
   const int ndim = pmb->pmy_mesh->ndim;
 
-  auto eos = eos_pkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   auto bounds = fix_pkg->Param<Bounds>("bounds");
 

--- a/src/fixup/fixup_radc2p.cpp
+++ b/src/fixup/fixup_radc2p.cpp
@@ -17,7 +17,6 @@
 
 #include <bvals/bvals_interfaces.hpp>
 #include <defs.hpp>
-#include <singularity-eos/eos/eos.hpp>
 
 #include "fluid/con2prim_robust.hpp"
 #include "fluid/prim2con.hpp"
@@ -38,7 +37,7 @@ using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using singularity::RadiationType;
+using Microphysics::RadiationType;
 
 namespace fixup {
 

--- a/src/fixup/fixup_radc2p.cpp
+++ b/src/fixup/fixup_radc2p.cpp
@@ -31,13 +31,13 @@
 #include "radiation/closure_mocmc.hpp"
 #include "radiation/radiation.hpp"
 
+using Microphysics::RadiationType;
 using radiation::ClosureEquation;
 using radiation::ClosureSettings;
 using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using Microphysics::RadiationType;
 
 namespace fixup {
 

--- a/src/fixup/fixup_src.cpp
+++ b/src/fixup/fixup_src.cpp
@@ -32,14 +32,14 @@
 #include "radiation/closure_mocmc.hpp"
 #include "radiation/radiation.hpp"
 
+using Microphysics::RadiationType;
+using Microphysics::EOS::EOS;
 using radiation::ClosureEquation;
 using radiation::ClosureSettings;
 using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using Microphysics::RadiationType;
-using Microphysics::EOS::EOS;
 
 namespace fixup {
 

--- a/src/fixup/fixup_src.cpp
+++ b/src/fixup/fixup_src.cpp
@@ -17,12 +17,12 @@
 
 #include <bvals/bvals_interfaces.hpp>
 #include <defs.hpp>
-#include <singularity-eos/eos/eos.hpp>
 
 #include "fluid/con2prim_robust.hpp"
 #include "fluid/fluid.hpp"
 #include "fluid/prim2con.hpp"
 #include "geometry/geometry.hpp"
+#include "microphysics/eos_phoebus/eos_phoebus.hpp"
 #include "phoebus_utils/programming_utils.hpp"
 #include "phoebus_utils/relativity_utils.hpp"
 #include "phoebus_utils/robust.hpp"
@@ -38,7 +38,8 @@ using radiation::ClosureVerbosity;
 using radiation::Tens2;
 using radiation::Vec;
 using robust::ratio;
-using singularity::RadiationType;
+using Microphysics::RadiationType;
+using Microphysics::EOS::EOS;
 
 namespace fixup {
 
@@ -70,7 +71,7 @@ TaskStatus SourceFixupImpl(T *rc) {
     return TaskStatus::complete;
   }
 
-  auto eos = eos_pkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eos_pkg->Param<EOS>("d.EOS");
   auto bounds = fix_pkg->Param<Bounds>("bounds");
 
   const std::vector<std::string> vars(

--- a/src/fluid/con2prim.hpp
+++ b/src/fluid/con2prim.hpp
@@ -21,11 +21,9 @@
 #include <parthenon/package.hpp>
 using namespace parthenon::package::prelude;
 
-// singulaarity
-#include <singularity-eos/eos/eos.hpp>
-
 #include "geometry/geometry.hpp"
 #include "geometry/geometry_utils.hpp"
+#include "microphysics/eos_phoebus/eos_phoebus.hpp"
 #include "phoebus_utils/cell_locations.hpp"
 #include "phoebus_utils/robust.hpp"
 #include "phoebus_utils/variables.hpp"
@@ -42,12 +40,12 @@ class Residual {
  public:
   KOKKOS_FUNCTION
   Residual(const Real D, const Real tau, const Real Bsq, const Real Ssq, const Real BdotS,
-           const singularity::EOS &eos)
+           const Microphysics::EOS::EOS &eos)
       : D_(D), tau_(tau), Bsq_(Bsq), Ssq_(Ssq), BdotSsq_(BdotS * BdotS),
         Ye_(std::numeric_limits<Real>::signaling_NaN()), eos_(eos) {}
   KOKKOS_FUNCTION
   Residual(const Real D, const Real tau, const Real Bsq, const Real Ssq, const Real BdotS,
-           const Real Ye, const singularity::EOS &eos)
+           const Real Ye, const Microphysics::EOS::EOS &eos)
       : D_(D), tau_(tau), Bsq_(Bsq), Ssq_(Ssq), BdotSsq_(BdotS * BdotS), Ye_(Ye),
         eos_(eos) {
     lambda_[0] = Ye_;
@@ -79,7 +77,7 @@ class Residual {
   }
 #endif
  private:
-  const singularity::EOS &eos_;
+  const Microphysics::EOS::EOS &eos_;
   const Real D_, tau_, Bsq_, Ssq_, BdotSsq_, Ye_;
   Real lambda_[2] = {0., 0.};
 };
@@ -165,14 +163,14 @@ class ConToPrim {
   }
 
   template <class... Args>
-  KOKKOS_INLINE_FUNCTION ConToPrimStatus operator()(const singularity::EOS &eos,
+  KOKKOS_INLINE_FUNCTION ConToPrimStatus operator()(const Microphysics::EOS::EOS &eos,
                                                     Args &&...args) const {
     VarAccessor<T> v(var, std::forward<Args>(args)...);
     return solve(v, eos);
   }
 
   template <typename CoordinateSystem, class... Args>
-  KOKKOS_INLINE_FUNCTION void Finalize(const singularity::EOS &eos,
+  KOKKOS_INLINE_FUNCTION void Finalize(const Microphysics::EOS::EOS &eos,
                                        const CoordinateSystem &geom,
                                        Args &&...args) const {
     VarAccessor<T> v(var, std::forward<Args>(args)...);
@@ -202,7 +200,7 @@ class ConToPrim {
 
   KOKKOS_INLINE_FUNCTION
   void finalize(const VarAccessor<T> &v, const CellGeom &g,
-                const singularity::EOS &eos) const {
+                const Microphysics::EOS::EOS &eos) const {
     const Real igdet = 1.0 / g.gdet;
     const Real &D = v(scr_lo + iD);
     const Real &Bsq = v(scr_lo + iBsq);
@@ -256,7 +254,7 @@ class ConToPrim {
   }
 
   KOKKOS_INLINE_FUNCTION
-  ConToPrimStatus solve(const VarAccessor<T> &v, const singularity::EOS &eos,
+  ConToPrimStatus solve(const VarAccessor<T> &v, const Microphysics::EOS::EOS &eos,
                         bool print = false) const {
     using robust::make_positive;
     using robust::ratio;

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -26,6 +26,7 @@ using namespace parthenon::package::prelude;
 #include "fixup/fixup.hpp"
 #include "geometry/geometry.hpp"
 #include "geometry/geometry_utils.hpp"
+#include "microphysics/eos_phoebus/eos_phoebus.hpp"
 #include "phoebus_utils/cell_locations.hpp"
 #include "phoebus_utils/robust.hpp"
 #include "phoebus_utils/root_find.hpp"

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -22,9 +22,6 @@
 #include <parthenon/package.hpp>
 using namespace parthenon::package::prelude;
 
-// singulaarity
-#include <singularity-eos/eos/eos.hpp>
-
 #include "con2prim_statistics.hpp"
 #include "fixup/fixup.hpp"
 #include "geometry/geometry.hpp"
@@ -50,7 +47,7 @@ class Residual {
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
            const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
-           const singularity::EOS &eos, const fixup::Bounds &bnds, const Real x1,
+           const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
            const Real x2, const Real x3, const Real floor_scale_fac)
       : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), v0sq_(v0sq),
         eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
@@ -165,7 +162,7 @@ class Residual {
 
  private:
   const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_;
-  const singularity::EOS &eos_;
+  const Microphysics::EOS::EOS &eos_;
   const fixup::Bounds &bounds_;
   const Real x1_, x2_, x3_;
   const Real floor_scale_fac_;
@@ -258,7 +255,7 @@ class ConToPrim {
 
   template <typename CoordinateSystem, class... Args>
   KOKKOS_INLINE_FUNCTION ConToPrimStatus operator()(const CoordinateSystem &geom,
-                                                    const singularity::EOS &eos,
+                                                    const Microphysics::EOS::EOS &eos,
                                                     const Coordinates_t &coords,
                                                     Args &&...args) const {
     VarAccessor<T> v(var, std::forward<Args>(args)...);
@@ -292,7 +289,7 @@ class ConToPrim {
 
   KOKKOS_INLINE_FUNCTION
   ConToPrimStatus solve(const VarAccessor<T> &v, const CellGeom &g,
-                        const singularity::EOS &eos, const Real x1, const Real x2,
+                        const Microphysics::EOS::EOS &eos, const Real x1, const Real x2,
                         const Real x3) const {
     int num_nans = std::isnan(v(crho)) + std::isnan(v(cmom_lo)) + std::isnan(v(ceng));
     if (num_nans > 0) return ConToPrimStatus::failure;

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -27,8 +27,6 @@
 #include "riemann.hpp"
 #include "tmunu.hpp"
 
-#include <singularity-eos/eos/eos.hpp>
-
 #include <globals.hpp>
 #include <kokkos_abstraction.hpp>
 #include <utils/error_checking.hpp>
@@ -462,7 +460,7 @@ TaskStatus ConservedToPrimitiveRobust(T *rc, const IndexRange &ib, const IndexRa
                                                 c2p_fail_on_ceilings);
 
   StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
-  auto eos = eos_pkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   auto coords = pmb->coords;
 
@@ -497,7 +495,7 @@ TaskStatus ConservedToPrimitiveClassic(T *rc, const IndexRange &ib, const IndexR
   auto invert = con2prim::ConToPrimSetup(rc, c2p_tol, c2p_max_iter);
 
   StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
-  auto eos = eos_pkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   auto fail = rc->Get(internal_variables::fail).data;
 

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -1,4 +1,4 @@
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -41,95 +41,51 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Params &params = pkg->AllParams();
 
   const std::string block_name = "eos";
-  auto FillRealParams = [&](ParameterInput *pin, EOSBuilder::params_t &params,
-                            const names_t &param_names) {
-    for (auto &name : param_names) {
-      params[name].emplace<Real>(pin->GetReal(block_name, name));
-    }
-  };
 
-  // Temporary EOS short-circuit
-  {
-    const Real gm1 = pin->GetReal(block_name, "Gamma") - 1.0;
-    const Real Cv = pin->GetReal(block_name, "Cv");
-    const bool needs_ye = false;
-
-    EOS eos_host = IdealGas(gm1, Cv);
-    EOS eos_device = eos_host.GetOnDevice();
-
-    params.Add("d.EOS", eos_device);
-    params.Add("h.EOS", eos_host);
-    params.Add("needs_ye", needs_ye);
-  }
-
-  printf("here\n");
-  exit(-1);
-
-  bool needs_ye = false; // TODO(JMM) descriptive enough?
-  names_t names;
-  EOSBuilder::EOSType type;
-  EOSBuilder::modifiers_t modifiers;
-  EOSBuilder::params_t base_params;
-  EOSBuilder::params_t relativity_params;
-  EOSBuilder::params_t units_params;
-  // EOSBuilder::params_t shifted_params, scaled_params;
+  phoebus::UnitConversions unit_conv(pin);
+  const Real time_unit = unit_conv.GetTimeCodeToCGS();
+  const Real mass_unit = unit_conv.GetMassCodeToCGS();
+  const Real length_unit = unit_conv.GetLengthCodeToCGS();
+  const Real temp_unit = unit_conv.GetTemperatureCodeToCGS();
+  const bool use_length_time = true;
 
   const std::vector<std::string> valid_eos_names = {IdealGas::EosType()
 #ifdef SPINER_USE_HDF
                                                         ,
-                                                    SpinerEOSDependsRhoT::EosType(),
-                                                    SpinerEOSDependsRhoSie::EosType()
+                                                    StellarCollapse::EosType()
 #endif
   };
+
   std::string eos_type = pin->GetString(block_name, std::string("type"));
   params.Add("type", eos_type);
   if (eos_type.compare(IdealGas::EosType()) == 0) {
-    type = EOSBuilder::EOSType::IdealGas;
-    names = {"Cv"};
-    Real gm1 = pin->GetReal(block_name, std::string("Gamma")) - 1.0;
-    params.Add("gm1", gm1);
-    base_params["gm1"].emplace<Real>(gm1);
-    /*
-      // TODO(JMM): Disabling these for now
-  } else if (eos_type.compare(Gruneisen::EosType()) == 0) {
-    type = EOSBuilder::EOSType::Gruneisen;
-    names = {"C0", "s1", "s2", "s3", "G0", "b", "rho0", "T0", "P0", "Cv"};
-  } else if (eos_type.compare(JWL::EosType()) == 0) {
-    type = EOSBuilder::EOSType::JWL;
-    names = {"A", "B", "R1", "R2", "w", "rho0", "Cv"};
-  } else if (eos_type.compare(DavisProducts::EosType()) == 0) {
-    type = EOSBuilder::EOSType::DavisProducts;
-    names = {"a", "b", "k", "n", "vc", "pc", "E0", "Cv"};
-  } else if (eos_type.compare(DavisReactants::EosType()) == 0) {
-    type = EOSBuilder::EOSType::DavisReactants;
-    names = {"rho0", "e0", "P0", "T0",    "A",  "B",
-             "C",    "G0", "Z",  "alpha", "Cv0"};
-    */
+    const Real gm1 = pin->GetReal(block_name, "Gamma") - 1.0;
+    const Real Cv = pin->GetReal(block_name, "Cv");
+
+    EOS eos_host = UnitSystem<IdealGas>(IdealGas(gm1, Cv),
+                                        eos_units_init::length_time_units_init_tag,
+                                        time_unit, mass_unit, length_unit, temp_unit);
+    EOS eos_device = eos_host.GetOnDevice();
+
+    params.Add("d.EOS", eos_device);
+    params.Add("h.EOS", eos_host);
 #ifdef SPINER_USE_HDF
-  } else if (eos_type.compare(SpinerEOSDependsRhoT::EosType()) == 0) {
-    type = EOSBuilder::EOSType::SpinerEOSDependsRhoT;
-    base_params["filename"].emplace<std::string>(pin->GetString(block_name, "filename"));
-    base_params["reproducibility_mode"].emplace<bool>(
-        pin->GetOrAddBoolean(block_name, "reproducibility_mode", false));
-    if (pin->DoesParameterExist("block_name", "sesame_id")) {
-      base_params["matid"].emplace<int>(pin->GetInteger(block_name, "sesame_id"));
-    } else if (pin->DoesParameterExist("block_name", "material_name")) {
-      base_params["materialName"].emplace<std::string>(
-          pin->GetString(block_name, "sesame_name"));
-    } else {
-      std::stringstream msg;
-      msg << "Neither sesame_id nor sesame_name exists for material " << block_name
-          << std::endl;
-      PARTHENON_THROW(msg);
-    }
   } else if (eos_type == StellarCollapse::EosType()) {
-    type = EOSBuilder::EOSType::StellarCollapse;
-    base_params["filename"].emplace<std::string>(pin->GetString(block_name, "filename"));
-    base_params["use_sp5"].emplace<bool>(
-        pin->GetOrAddBoolean(block_name, "use_sp5", true));
-    auto use_ye = pin->GetOrAddBoolean("fluid", "Ye", false);
+    const std::string filename = pin->GetString(block_name, "filename");
+    const bool use_sp5 = pin->GetOrAddBoolean(block_name, "use_sp5", true);
+    const bool filter_bmod = pin->GetOrAddBoolean(block_name, "filter_bmod", true);
+    const bool use_ye = pin->GetOrAddBoolean("fluid", "Ye", false);
     PARTHENON_REQUIRE_THROWS(use_ye,
                              "\"StellarCollapse\" EOS requires that Ye be enabled!");
+
+    EOS eos_host =
+        UnitSystem<StellarCollapse>(StellarCollapse(filename, use_sp5, filter_bmod),
+                                    eos_units_init::length_time_units_init_tag, time_unit,
+                                    mass_unit, length_unit, temp_unit);
+    EOS eos_device = eos_host.GetOnDevice();
+
+    params.Add("d.EOS", eos_device);
+    params.Add("h.EOS", eos_host);
 #endif
   } else {
     std::stringstream error_mesg;
@@ -141,93 +97,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     error_mesg << std::endl;
     PARTHENON_THROW(error_mesg);
   }
-  FillRealParams(pin, base_params, names);
-
-  phoebus::UnitConversions unit_conv(pin);
-
-  // modifiers
-  /*
-  // TODO(JMM): Disabling this for now
-  Real shift = pin->GetOrAddReal(block_name, "shift", 0.0);
-  Real scale = pin->GetOrAddReal(block_name, "scale", 1.0);
-  if (shift != 0.0) {
-    shifted_params["shift"].emplace<Real>(shift);
-    modifiers[EOSBuilder::EOSModifier::Shifted] = shifted_params;
-  }
-  if (scale != 1.0) {
-    scaled_params["scale"].emplace<Real>(scale);
-    modifiers[EOSBuilder::EOSModifier::Scaled] = scaled_params;
-  }
-  */
-  units_params["use_length_time"].emplace<bool>(true);
-  units_params["time_unit"].emplace<Real>(unit_conv.GetTimeCodeToCGS());
-  units_params["length_unit"].emplace<Real>(unit_conv.GetLengthCodeToCGS());
-  units_params["mass_unit"].emplace<Real>(unit_conv.GetMassCodeToCGS());
-  units_params["temp_unit"].emplace<Real>(unit_conv.GetTemperatureCodeToCGS());
-  modifiers[EOSBuilder::EOSModifier::UnitSystem] = units_params;
-
-  // Build the EOS
-  singularity::EOS eos_host = EOSBuilder::buildEOS(type, base_params, modifiers);
-  singularity::EOS eos_device = eos_host.GetOnDevice();
-
-  params.Add("d.EOS", eos_device);
-  params.Add("h.EOS", eos_host);
-  params.Add("needs_ye", needs_ye);
-
-  // Store eos params in case they're needed
-  for (auto &name : names) {
-    params.Add(name, (pin->GetReal(block_name, name)));
-  }
-
-  // If using StellarCollapse, we need additional variables.
-  // We also need table max and min values, regardless of the EOS.
-  // These can be used for floors/ceilings or for root find bounds
-  Real rho_min = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
-  Real sie_min = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
-  Real lambda[2] = {0.};
-  Real T_min = eos_host.TemperatureFromDensityInternalEnergy(rho_min, sie_min, lambda);
-  Real rho_max = pin->GetOrAddReal("fixup", "rho0_ceiling", 1e18);
-  Real sie_max = pin->GetOrAddReal("fixup", "sie0_ceiling", 1e35);
-  Real T_max = eos_host.TemperatureFromDensityInternalEnergy(rho_max, sie_max, lambda);
-#ifdef SPINER_USE_HDF
-  if (eos_type == StellarCollapse::EosType()) {
-    // We request that Ye and temperature exist, but do not provide them.
-    Metadata m = Metadata({Metadata::Cell, Metadata::Intensive, Metadata::Derived,
-                           Metadata::OneCopy, Metadata::Requires});
-
-    pkg->AddField(fluid_prim::ye, m);
-    pkg->AddField(fluid_prim::temperature, m);
-
-    // TODO(JMM): To get around current limitations of
-    // singularity-eos, I just load the table and throw it away.  This
-    // will be resolved in a future version of singularity-eos.
-    // See issue #69.
-    singularity::StellarCollapse eos_sc(pin->GetString(block_name, "filename"),
-                                        pin->GetOrAddBoolean(block_name, "use_sp5", true),
-                                        false);
-    Real M_unit = unit_conv.GetMassCodeToCGS();
-    Real L_unit = unit_conv.GetLengthCodeToCGS();
-    Real rho_unit = M_unit / std::pow(L_unit, 3);
-    Real T_unit = unit_conv.GetTemperatureCodeToCGS();
-    // Always C^2
-    Real sie_unit = std::pow(pc.c, 2);
-    Real press_unit = rho_unit * sie_unit;
-
-    sie_min = eos_sc.sieMin() / sie_unit;
-    sie_max = eos_sc.sieMax() / sie_unit;
-    T_min = eos_sc.TMin() / T_unit;
-    T_max = eos_sc.TMax() / T_unit;
-    rho_min = eos_sc.rhoMin() / rho_unit;
-    rho_max = eos_sc.rhoMax() / rho_unit;
-  }
-#endif // SPINER_USE_HDF
-
-  params.Add("sie_min", sie_min);
-  params.Add("sie_max", sie_max);
-  params.Add("T_min", T_min);
-  params.Add("T_max", T_max);
-  params.Add("rho_min", rho_min);
-  params.Add("rho_max", rho_max);
 
   return pkg;
 }

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -48,25 +48,22 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     }
   };
 
-
   // Temporary EOS short-circuit
-  {const Real gm1 = pin->GetReal(block_name, "Gamma") - 1.0;
-  const Real Cv = pin->GetReal(block_name, "Cv");
-  const bool needs_ye = false;
+  {
+    const Real gm1 = pin->GetReal(block_name, "Gamma") - 1.0;
+    const Real Cv = pin->GetReal(block_name, "Cv");
+    const bool needs_ye = false;
 
+    EOS eos_host = IdealGas(gm1, Cv);
+    EOS eos_device = eos_host.GetOnDevice();
 
-  EOS eos_host = IdealGas(gm1, Cv);
-  EOS eos_device = eos_host.GetOnDevice();
-
-  params.Add("d.EOS", eos_device);
-  params.Add("h.EOS", eos_host);
-  params.Add("needs_ye", needs_ye);
-}
-
+    params.Add("d.EOS", eos_device);
+    params.Add("h.EOS", eos_host);
+    params.Add("needs_ye", needs_ye);
+  }
 
   printf("here\n");
   exit(-1);
-
 
   bool needs_ye = false; // TODO(JMM) descriptive enough?
   names_t names;

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -48,6 +48,26 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     }
   };
 
+
+  // Temporary EOS short-circuit
+  {const Real gm1 = pin->GetReal(block_name, "Gamma") - 1.0;
+  const Real Cv = pin->GetReal(block_name, "Cv");
+  const bool needs_ye = false;
+
+
+  EOS eos_host = IdealGas(gm1, Cv);
+  EOS eos_device = eos_host.GetOnDevice();
+
+  params.Add("d.EOS", eos_device);
+  params.Add("h.EOS", eos_host);
+  params.Add("needs_ye", needs_ye);
+}
+
+
+  printf("here\n");
+  exit(-1);
+
+
   bool needs_ye = false; // TODO(JMM) descriptive enough?
   names_t names;
   EOSBuilder::EOSType type;

--- a/src/microphysics/eos_phoebus/eos_phoebus.hpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.hpp
@@ -26,7 +26,17 @@ namespace Microphysics {
 //  using MyEOS=singularity::impl::Variant<IdealGas>;
 
 namespace EOS {
-using EOS = singularity::UnmodifiedEOS;
+
+#ifdef SPINER_USE_HDF
+using UnmodifiedEOS =
+    singularity::Variant<singularity::IdealGas, singularity::SpinerEOSDependsRhoT,
+                         singularity::SpinerEOSDependsRhoSie,
+                         singularity::StellarCollapse>;
+#else
+using UnmodifiedEOS = singularity::Variant<singularity::IdealGas>;
+#endif
+
+using EOS = UnmodifiedEOS;
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 } // namespace EOS

--- a/src/microphysics/eos_phoebus/eos_phoebus.hpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.hpp
@@ -1,4 +1,4 @@
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -28,15 +28,12 @@ namespace Microphysics {
 namespace EOS {
 
 #ifdef SPINER_USE_HDF
-using UnmodifiedEOS =
-    singularity::Variant<singularity::IdealGas, singularity::SpinerEOSDependsRhoT,
-                         singularity::SpinerEOSDependsRhoSie,
-                         singularity::StellarCollapse>;
+using EOS =
+    singularity::Variant<singularity::UnitSystem<singularity::IdealGas>,
+                         singularity::UnitSystem<singularity::StellarCollapse>>;
 #else
-using UnmodifiedEOS = singularity::Variant<singularity::IdealGas>;
+using EOS = singularity::Variant<singularity::UnitSystem<singularity::IdealGas>>;
 #endif
-
-using EOS = UnmodifiedEOS;
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 } // namespace EOS

--- a/src/microphysics/eos_phoebus/eos_phoebus.hpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.hpp
@@ -28,9 +28,8 @@ namespace Microphysics {
 namespace EOS {
 
 #ifdef SPINER_USE_HDF
-using EOS =
-    singularity::Variant<singularity::UnitSystem<singularity::IdealGas>,
-                         singularity::UnitSystem<singularity::StellarCollapse>>;
+using EOS = singularity::Variant<singularity::UnitSystem<singularity::IdealGas>,
+                                 singularity::UnitSystem<singularity::StellarCollapse>>;
 #else
 using EOS = singularity::Variant<singularity::UnitSystem<singularity::IdealGas>>;
 #endif

--- a/src/microphysics/eos_phoebus/eos_phoebus.hpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.hpp
@@ -17,11 +17,17 @@
 #include <memory>
 #include <parthenon/package.hpp>
 
+#include <singularity-eos/eos/eos.hpp>
+
 using namespace parthenon::package::prelude;
 
 namespace Microphysics {
 
+//  using MyEOS=singularity::impl::Variant<IdealGas>;
+
 namespace EOS {
+using EOS = singularity::UnmodifiedEOS;
+
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 } // namespace EOS
 

--- a/src/monopole_gr/monopole_gr.cpp
+++ b/src/monopole_gr/monopole_gr.cpp
@@ -28,9 +28,6 @@
 #include <parthenon/package.hpp>
 #include <utils/error_checking.hpp>
 
-// Singularity
-#include <singularity-eos/eos/eos.hpp>
-
 // Phoebus
 #include "geometry/geometry_utils.hpp"
 #include "microphysics/eos_phoebus/eos_phoebus.hpp"

--- a/src/pgen/advection.cpp
+++ b/src/pgen/advection.cpp
@@ -58,7 +58,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
 
   pmb->par_for(
       "Phoebus::ProblemGenerator::advection", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,

--- a/src/pgen/blandford_mckee.cpp
+++ b/src/pgen/blandford_mckee.cpp
@@ -61,7 +61,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");
 

--- a/src/pgen/bondi.cpp
+++ b/src/pgen/bondi.cpp
@@ -134,7 +134,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
 
   const Real a = pin->GetReal("geometry", "a");
   auto bl = Geometry::BoyerLindquist(a);

--- a/src/pgen/friedmann.cpp
+++ b/src/pgen/friedmann.cpp
@@ -52,7 +52,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real eps = pin->GetOrAddReal("friedmann", "sie", 1.0);
   const Real u = rho * eps;
 
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
 
   IndexRange ib = rc->GetBoundsI(IndexDomain::entire);
   IndexRange jb = rc->GetBoundsJ(IndexDomain::entire);

--- a/src/pgen/kh.cpp
+++ b/src/pgen/kh.cpp
@@ -62,7 +62,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");
 

--- a/src/pgen/leptoneq.cpp
+++ b/src/pgen/leptoneq.cpp
@@ -50,7 +50,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   auto &coords = pmb->coords;
   auto eospkg = pmb->packages.Get("eos");
-  auto eos = eospkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eospkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto &unit_conv =
       pmb->packages.Get("phoebus")->Param<phoebus::UnitConversions>("unit_conv");
 

--- a/src/pgen/linear_modes.cpp
+++ b/src/pgen/linear_modes.cpp
@@ -157,7 +157,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   Real cs = omega.imag() / (std::sqrt(2) * kk);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto gpkg = pmb->packages.Get("geometry");
   auto geom = Geometry::GetCoordinateSystem(rc.get());
 

--- a/src/pgen/p2c2p.cpp
+++ b/src/pgen/p2c2p.cpp
@@ -93,7 +93,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc.get());
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -75,8 +75,8 @@ class PressResidual {
 };
 
 KOKKOS_FUNCTION
-Real energy_from_rho_P(const EOS &eos, const Real rho, const Real P,
-                       const Real emin, const Real emax, const Real Ye) {
+Real energy_from_rho_P(const EOS &eos, const Real rho, const Real P, const Real emin,
+                       const Real emax, const Real Ye) {
   PARTHENON_REQUIRE(P >= 0, "Pressure is negative!");
   PressResidual res(eos, rho, P, Ye);
   root_find::RootFind root;

--- a/src/pgen/pgen.cpp
+++ b/src/pgen/pgen.cpp
@@ -18,6 +18,8 @@
 
 namespace phoebus {
 
+using Microphysics::EOS::EOS;
+
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   std::string name = pin->GetString("phoebus", "problem");
 
@@ -57,7 +59,7 @@ void PostInitializationModifier(ParameterInput *pin, Mesh *pmesh) {
 class PressResidual {
  public:
   KOKKOS_INLINE_FUNCTION
-  PressResidual(const singularity::EOS &eos, const Real rho, const Real P, const Real Ye)
+  PressResidual(const EOS &eos, const Real rho, const Real P, const Real Ye)
       : eos_(eos), rho_(rho), P_(P) {
     lambda_[0] = Ye;
   }
@@ -67,13 +69,13 @@ class PressResidual {
   }
 
  private:
-  const singularity::EOS &eos_;
+  const EOS &eos_;
   Real rho_, P_;
   Real lambda_[2];
 };
 
 KOKKOS_FUNCTION
-Real energy_from_rho_P(const singularity::EOS &eos, const Real rho, const Real P,
+Real energy_from_rho_P(const EOS &eos, const Real rho, const Real P,
                        const Real emin, const Real emax, const Real Ye) {
   PARTHENON_REQUIRE(P >= 0, "Pressure is negative!");
   PressResidual res(eos, rho, P, Ye);

--- a/src/pgen/pgen.hpp
+++ b/src/pgen/pgen.hpp
@@ -19,9 +19,6 @@
 #include <utils/error_checking.hpp>
 using namespace parthenon::package::prelude;
 
-// singularity includes
-#include <singularity-eos/eos/eos.hpp>
-
 // internal includes
 #include "fluid/fluid.hpp"
 #include "geometry/geometry.hpp"
@@ -119,7 +116,7 @@ static std::map<std::string, std::function<void(ParameterInput *pin, Mesh *pmesh
 */
 
 KOKKOS_FUNCTION
-Real energy_from_rho_P(const singularity::EOS &eos, const Real rho, const Real P,
+Real energy_from_rho_P(const Microphysics::EOS::EOS &eos, const Real rho, const Real P,
                        const Real emin, const Real emax, const Real Ye = 0.0);
 
 } // namespace phoebus

--- a/src/pgen/radiation_advection.cpp
+++ b/src/pgen/radiation_advection.cpp
@@ -45,7 +45,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   Params &phoebus_params = pmb->packages.Get("phoebus")->AllParams();
 
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto &unit_conv =
       pmb->packages.Get("phoebus")->Param<phoebus::UnitConversions>("unit_conv");
   const Real MASS = unit_conv.GetMassCGSToCode();
@@ -86,7 +86,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   phoebus_params.Add("radiation_advection/Hz", Hz);
 
   auto rad = pmb->packages.Get("radiation").get();
-  auto species = rad->Param<std::vector<singularity::RadiationType>>("species");
+  auto species = rad->Param<std::vector<Microphysics::RadiationType>>("species");
   auto num_species = rad->Param<int>("num_species");
 
   const Real W = 1 / sqrt(1 - vx * vx);

--- a/src/pgen/radiation_equilibration.cpp
+++ b/src/pgen/radiation_equilibration.cpp
@@ -19,8 +19,8 @@
 
 namespace radiation_equilibration {
 
-using radiation::species;
 using Microphysics::RadiationType;
+using radiation::species;
 
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 

--- a/src/pgen/radiation_equilibration.cpp
+++ b/src/pgen/radiation_equilibration.cpp
@@ -20,7 +20,7 @@
 namespace radiation_equilibration {
 
 using radiation::species;
-using singularity::RadiationType;
+using Microphysics::RadiationType;
 
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
@@ -58,7 +58,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   const auto opac =
       pmb->packages.Get("opacity")->template Param<Microphysics::Opacities>("opacities");
 

--- a/src/pgen/rhs_tester.cpp
+++ b/src/pgen/rhs_tester.cpp
@@ -41,7 +41,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");
 

--- a/src/pgen/rotor.cpp
+++ b/src/pgen/rotor.cpp
@@ -60,7 +60,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");
   auto gpkg = pmb->packages.Get("geometry");

--- a/src/pgen/sedov.cpp
+++ b/src/pgen/sedov.cpp
@@ -65,7 +65,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");
 

--- a/src/pgen/shock_tube.cpp
+++ b/src/pgen/shock_tube.cpp
@@ -69,7 +69,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto &coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc.get());
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");

--- a/src/pgen/thin_cooling.cpp
+++ b/src/pgen/thin_cooling.cpp
@@ -50,7 +50,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   auto &coords = pmb->coords;
   auto eospkg = pmb->packages.Get("eos");
-  auto eos = eospkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eospkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto &unit_conv =
       pmb->packages.Get("phoebus")->Param<phoebus::UnitConversions>("unit_conv");
 

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -40,7 +40,7 @@ using pc = parthenon::constants::PhysicalConstants<parthenon::constants::CGS>;
 
 using namespace radiation;
 using Microphysics::Opacities;
-using singularity::EOS;
+using Microphysics::EOS::EOS;
 
 class GasRadTemperatureResidual {
  public:
@@ -140,7 +140,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<EOS>("d.EOS");
   auto floor = pmb->packages.Get("fixup")->Param<fixup::Floors>("floor");
 
   auto geom = Geometry::GetCoordinateSystem(rc);

--- a/src/pgen/tov.cpp
+++ b/src/pgen/tov.cpp
@@ -58,7 +58,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   auto intrinsic = tov_pkg->Param<TOV::State_t>("tov_intrinsic");
 
   auto coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
+  auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
 
   const auto pmin = tov_pkg->Param<Real>("pmin");
   const Real rhomin = pin->GetOrAddReal("tov", "rhomin", 1e-12);

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -18,7 +18,7 @@
 namespace radiation {
 
 using Microphysics::Opacities;
-using singularity::RadiationType;
+using Microphysics::RadiationType;
 
 TaskStatus CoolingFunctionCalculateFourForce(MeshBlockData<Real> *rc, const double dt) {
   namespace p = fluid_prim;

--- a/src/radiation/mocmc.cpp
+++ b/src/radiation/mocmc.cpp
@@ -16,8 +16,6 @@
 #include <kokkos_abstraction.hpp>
 #include <utils/error_checking.hpp>
 
-// singularity
-#include <singularity-eos/eos/eos.hpp>
 
 #include "closure.hpp"
 #include "closure_mocmc.hpp"
@@ -38,8 +36,8 @@ namespace pr = radmoment_prim;
 namespace ir = radmoment_internal;
 namespace im = mocmc_internal;
 using Microphysics::Opacities;
-using singularity::EOS;
-using singularity::RadiationType;
+using Microphysics::EOS::EOS;
+using Microphysics::RadiationType;
 using vpack_types::FlatIdx;
 
 constexpr int MAX_SPECIES = 3;

--- a/src/radiation/mocmc.cpp
+++ b/src/radiation/mocmc.cpp
@@ -16,7 +16,6 @@
 #include <kokkos_abstraction.hpp>
 #include <utils/error_checking.hpp>
 
-
 #include "closure.hpp"
 #include "closure_mocmc.hpp"
 #include "geodesics.hpp"
@@ -36,8 +35,8 @@ namespace pr = radmoment_prim;
 namespace ir = radmoment_internal;
 namespace im = mocmc_internal;
 using Microphysics::Opacities;
-using Microphysics::EOS::EOS;
 using Microphysics::RadiationType;
+using Microphysics::EOS::EOS;
 using vpack_types::FlatIdx;
 
 constexpr int MAX_SPECIES = 3;

--- a/src/radiation/moments.cpp
+++ b/src/radiation/moments.cpp
@@ -15,8 +15,6 @@
 #include <kokkos_abstraction.hpp>
 #include <utils/error_checking.hpp>
 
-#include <singularity-eos/eos/eos.hpp>
-
 #include "phoebus_utils/linear_algebra.hpp"
 #include "phoebus_utils/programming_utils.hpp"
 #include "phoebus_utils/root_find.hpp"
@@ -34,7 +32,7 @@ namespace radiation {
 
 using fixup::Bounds;
 using Microphysics::Opacities;
-using singularity::EOS;
+using Microphysics::EOS::EOS;
 
 template <class T>
 class ReconstructionIndexer {

--- a/src/radiation/moments_source.cpp
+++ b/src/radiation/moments_source.cpp
@@ -15,8 +15,6 @@
 #include <kokkos_abstraction.hpp>
 #include <utils/error_checking.hpp>
 
-#include <singularity-eos/eos/eos.hpp>
-
 #include "phoebus_utils/linear_algebra.hpp"
 #include "phoebus_utils/programming_utils.hpp"
 #include "phoebus_utils/root_find.hpp"
@@ -35,7 +33,7 @@ namespace radiation {
 
 using fixup::Bounds;
 using Microphysics::Opacities;
-using singularity::EOS;
+using Microphysics::EOS::EOS;
 
 template <typename CLOSURE>
 class SourceResidual4 {
@@ -212,7 +210,7 @@ TaskStatus MomentFluidSourceImpl(T *rc, Real dt, bool update_fluid) {
   StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
   StateDescriptor *opac = pmb->packages.Get("opacity").get();
   StateDescriptor *fix_pkg = pmb->packages.Get("fixup").get();
-  auto eos = eos_pkg->Param<singularity::EOS>("d.EOS");
+  auto eos = eos_pkg->Param<EOS>("d.EOS");
   namespace cr = radmoment_cons;
   namespace pr = radmoment_prim;
   namespace ir = radmoment_internal;

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -31,6 +31,7 @@ using namespace parthenon;
 #include "phoebus_utils/variables.hpp"
 
 #include "microphysics/opac_phoebus/opac_phoebus.hpp"
+#include "microphysics/eos_phoebus/eos_phoebus.hpp"
 
 using namespace phoebus;
 
@@ -56,7 +57,7 @@ enum class ReconFixupStrategy {
 };
 
 using pc = parthenon::constants::PhysicalConstants<parthenon::constants::CGS>;
-using singularity::RadiationType;
+using Microphysics::RadiationType;
 
 constexpr int MaxNumRadiationSpecies = 3;
 constexpr RadiationType species[MaxNumRadiationSpecies] = {

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -30,8 +30,8 @@ using namespace parthenon;
 #include "phoebus_utils/relativity_utils.hpp"
 #include "phoebus_utils/variables.hpp"
 
-#include "microphysics/opac_phoebus/opac_phoebus.hpp"
 #include "microphysics/eos_phoebus/eos_phoebus.hpp"
+#include "microphysics/opac_phoebus/opac_phoebus.hpp"
 
 using namespace phoebus;
 

--- a/src/tov/tov.cpp
+++ b/src/tov/tov.cpp
@@ -24,9 +24,6 @@
 
 using namespace parthenon::package::prelude;
 
-// Singularity
-#include <singularity-eos/eos/eos.hpp>
-
 // Phoebus
 #include "analysis/history.hpp"
 #include "geometry/geometry_utils.hpp"


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`phoebus` compilation has become very slow. One possible explanation is the combinatorial explosion of modifiers in `singularity-eos`. We don't need these, so this PR is an attempt to short-circuit that machinery.

Additionally, this PR reorganizes the code a bit such that the singularity namespace is only used in code inside the `phoebus/src/microphysics` directory.

This PR compiles from scratch (including submodules) for me in 6m19s and the build directory is 2.7 GB, whereas `main` takes 8m4s and the build directory is 4.3 GB.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
