### PR TITLE
Fix restriction bug on initialization

### DIFF
--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -29,7 +29,10 @@
 
 #include <globals.hpp>
 #include <kokkos_abstraction.hpp>
+#include <parthenon/package.hpp>
 #include <utils/error_checking.hpp>
+
+using parthenon::MetadataFlag;
 
 // statically defined vars from riemann.hpp
 std::vector<std::string> riemann::FluxState::recon_vars, riemann::FluxState::flux_vars;
@@ -164,10 +167,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
         "\"bc_vars\" must be either \"conserved\" or \"primitive\"!");
   }
 
-  Metadata mprim_threev = Metadata(prim_flags_vec, three_vec);
+  Metadata mprim_threev = Metadata(prim_flags_vector, three_vec);
   Metadata mprim_scalar = Metadata(prim_flags_scalar);
   Metadata mcons_scalar = Metadata(cons_flags_scalar);
-  Metadata mcons_threev = Metadata(cons_flags_vec, three_vec);
+  Metadata mcons_threev = Metadata(cons_flags_vector, three_vec);
 
   // TODO(BRR) Should these go in a "phoebus" package?
   const std::string ix1_bc = pin->GetString("phoebus", "ix1_bc");

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -29,14 +29,21 @@
 #include "phoebus_utils/unit_conversions.hpp"
 #include "phoebus_utils/variables.hpp"
 
+using namespace singularity;
+
 namespace Microphysics {
 namespace EOS {
 
 parthenon::constants::PhysicalConstants<parthenon::constants::CGS> pc;
 
 using names_t = std::vector<std::string>;
+const names_t valid_eos_names = {IdealGas::EosType()
+#ifdef SPINER_USE_HDF		
+				 , StellarCollapse::EosType()
+#endif				 
+};	 
+
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
-  using namespace singularity;
   auto pkg = std::make_shared<StateDescriptor>("eos");
   Params &params = pkg->AllParams();
 
@@ -47,14 +54,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   const Real mass_unit = unit_conv.GetMassCodeToCGS();
   const Real length_unit = unit_conv.GetLengthCodeToCGS();
   const Real temp_unit = unit_conv.GetTemperatureCodeToCGS();
-  const bool use_length_time = true;
-
-  const std::vector<std::string> valid_eos_names = {IdealGas::EosType()
-#ifdef SPINER_USE_HDF
-                                                        ,
-                                                    StellarCollapse::EosType()
-#endif
-  };
 
   // If using StellarCollapse, we need additional variables.
   // We also need table max and min values, regardless of the EOS.

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -38,10 +38,11 @@ parthenon::constants::PhysicalConstants<parthenon::constants::CGS> pc;
 
 using names_t = std::vector<std::string>;
 const names_t valid_eos_names = {IdealGas::EosType()
-#ifdef SPINER_USE_HDF		
-				 , StellarCollapse::EosType()
-#endif				 
-};	 
+#ifdef SPINER_USE_HDF
+                                     ,
+                                 StellarCollapse::EosType()
+#endif
+};
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto pkg = std::make_shared<StateDescriptor>("eos");

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -443,8 +443,8 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
         flux_div /*| geom_src*/, fluid::CopyFluxDivergence<MeshData<Real>>, mdudt.get());
 #endif
 
-    auto add_rhs = tl.AddTask(flux_div, SumData<std::string, MeshData<Real>>,
-                              src_names, mdudt.get(), mgsrc.get(), mdudt.get());
+    auto add_rhs = tl.AddTask(flux_div, SumData<std::string, MeshData<Real>>, src_names,
+                              mdudt.get(), mgsrc.get(), mdudt.get());
 
     auto avg_data = tl.AddTask(flux_div, AverageIndependentData<MeshData<Real>>,
                                mc0.get(), mbase.get(), beta);

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -443,8 +443,8 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
         flux_div /*| geom_src*/, fluid::CopyFluxDivergence<MeshData<Real>>, mdudt.get());
 #endif
 
-    auto add_rhs = tl.AddTask(flux_div, SumData<std::string, MeshData<Real>>, src_names,
-                              mdudt.get(), mgsrc.get(), mdudt.get());
+    auto add_rhs = tl.AddTask(flux_div, SumData<std::vector<std::string>, MeshData<Real>>,
+                              src_names, mdudt.get(), mgsrc.get(), mdudt.get());
 
     auto avg_data = tl.AddTask(flux_div, AverageIndependentData<MeshData<Real>>,
                                mc0.get(), mbase.get(), beta);

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -443,7 +443,7 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
         flux_div /*| geom_src*/, fluid::CopyFluxDivergence<MeshData<Real>>, mdudt.get());
 #endif
 
-    auto add_rhs = tl.AddTask(flux_div, SumData<std::vector<std::string>, MeshData<Real>>,
+    auto add_rhs = tl.AddTask(flux_div, SumData<std::string, MeshData<Real>>,
                               src_names, mdudt.get(), mgsrc.get(), mdudt.get());
 
     auto avg_data = tl.AddTask(flux_div, AverageIndependentData<MeshData<Real>>,

--- a/tst/phoebus_unit_test_main.cpp
+++ b/tst/phoebus_unit_test_main.cpp
@@ -1,4 +1,4 @@
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2023 Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Upon updating parthenon, @brryan found that Phoebus was crashing when restriction was called. The issue turned out to be a subtle interaction between `Metadata` and the custom prolongation/restriction operations. Essentially primitive  and/or conserved variables need to be set for prolongation/restriction when they are used for boundary conditions. However, they were being set with an "empty" prolongation/restriction operator and the code was crashing when the stored functor was a `nullptr`.

This was happening because because `Metadata::FillGhost` was being set after the constructor for the metadata object was called, but the default prolongation/restriction ops are currently only set when `Metadata` is constructed. 

I fix this issue here by creating `Metadata` objects once and not changing their flags after construction. There should also be some changes in `parthenon` to guard against this in the future. But this fixes Phoebus for now.

I also tweak the `eos_phoebus.cpp` file while I was debugging. Essentially I just moved the vector of valid names outside `initialize`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
