### PR TITLE
Get torus working with nuclear EoS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS On)
 # TODO(JMM): Pgen?
 include(CTest)
 option(PHOEBUS_ENABLE_UNIT_TESTS "Enable unit tests" OFF)
+option(PHOEBUS_ENABLE_DOWNLOADS "Enable table download" OFF)
 option(PHOEBUS_ENABLE_INTEGRATION_TESTS "Enable integration tests" OFF)
 option(PHOEBUS_ENABLE_REGRESSION_TESTS "Enable regression tests" OFF)
 option(PHOEBUS_ENABLE_CUDA "Enable cuda for riot and all dependencies" OFF)

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -153,4 +153,4 @@ entropy = 4
 <units>
 scale_free = false
 geom_mass_msun = 2.8
-fluid_density_g = 1.e11
+fluid_density_cgs = 1.e11

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -82,11 +82,10 @@ method = derivative_order_1
 max_level = 3
 
 <eos>
-# type = IdealGas
-type = StellarCollapse
-filter_bmod = false
-filename = ../../Data/sfho.h5
-use_sp5 = false
+type = IdealGas
+#type = StellarCollapse
+#filename = ../../Data/sfho.h5
+#use_sp5 = false
 Gamma = 1.66666666666666666666666667
 Cv = 1.0
 
@@ -143,7 +142,8 @@ n_inside_horizon = 5
 magnetized = true
 entropy = 4
 
-<units>
-scale_free = false
-geom_mass_msun = 2.8
-fluid_mass_g = 1.e26
+# For tabulated EoS
+#<units>
+#scale_free = false
+#geom_mass_msun = 2.8
+#fluid_density_g = 1.e11

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -94,6 +94,7 @@ Gamma = 1.66666666666666666666666667
 Cv = 1.0
 rho_min = 1e-8
 sie_min = 1e-8
+nsamps_adiabat = 180
 
 <physics>
 hydro = true

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -25,6 +25,9 @@ variables = p.density,       &
             c.energy,        &
             pressure,      	 &
             g.c.coord,       &
+            g.f1.coord,       &
+            g.f2.coord,       &
+            g.f3.coord,       &
             g.n.coord,       &
             g.c.detgam,      &
             g.c.bcon,        &
@@ -82,12 +85,15 @@ method = derivative_order_1
 max_level = 3
 
 <eos>
-type = IdealGas
-#type = StellarCollapse
-#filename = ../../Data/sfho.h5
-#use_sp5 = false
+#type = IdealGas
+type = StellarCollapse
+filename = ../../Data/sfho.h5
+use_sp5 = false
+filter_bmod = false
 Gamma = 1.66666666666666666666666667
 Cv = 1.0
+rho_min = 1e-8
+sie_min = 1e-8
 
 <physics>
 hydro = true
@@ -103,7 +109,7 @@ recon = weno5
 c2p_max_iter = 100
 c2p_tol = 1.e-8
 c2p_method = robust
-Ye = true
+Ye = false
 mhd = true
 
 <geometry>
@@ -143,7 +149,7 @@ magnetized = true
 entropy = 4
 
 # For tabulated EoS
-#<units>
-#scale_free = false
-#geom_mass_msun = 2.8
-#fluid_density_g = 1.e11
+<units>
+scale_free = false
+geom_mass_msun = 2.8
+fluid_density_g = 1.e11

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -82,7 +82,11 @@ method = derivative_order_1
 max_level = 3
 
 <eos>
-type = IdealGas
+# type = IdealGas
+type = StellarCollapse
+filter_bmod = false
+filename = ../../Data/sfho.h5
+use_sp5 = false
 Gamma = 1.66666666666666666666666667
 Cv = 1.0
 
@@ -100,7 +104,7 @@ recon = weno5
 c2p_max_iter = 100
 c2p_tol = 1.e-8
 c2p_method = robust
-Ye = false
+Ye = true
 mhd = true
 
 <geometry>
@@ -137,3 +141,9 @@ rin = 6.0
 rmax = 12.0
 n_inside_horizon = 5
 magnetized = true
+entropy = 4
+
+<units>
+scale_free = false
+geom_mass_msun = 2.8
+fluid_mass_g = 1.e26

--- a/inputs/torus.pin
+++ b/inputs/torus.pin
@@ -85,11 +85,10 @@ method = derivative_order_1
 max_level = 3
 
 <eos>
-#type = IdealGas
-type = StellarCollapse
-filename = ../../Data/sfho.h5
-use_sp5 = false
-filter_bmod = false
+type = IdealGas
+#type = StellarCollapse
+#filename = ../../Data/sfho.h5
+#use_sp5 = false
 Gamma = 1.66666666666666666666666667
 Cv = 1.0
 rho_min = 1e-8
@@ -150,7 +149,7 @@ magnetized = true
 entropy = 4
 
 # For tabulated EoS
-<units>
-scale_free = false
-geom_mass_msun = 2.8
-fluid_density_cgs = 1.e11
+#<units>
+#scale_free = false
+#geom_mass_msun = 2.8
+#fluid_density_cgs = 1.e11

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(phoebus
   phoebus_package.cpp
   phoebus_package.hpp
 
+  phoebus_utils/adiabats.hpp
   phoebus_utils/cell_locations.hpp
   phoebus_utils/unit_conversions.cpp
   phoebus_utils/unit_conversions.hpp

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -111,6 +111,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     base_params["filename"].emplace<std::string>(pin->GetString(block_name, "filename"));
     base_params["use_sp5"].emplace<bool>(
         pin->GetOrAddBoolean(block_name, "use_sp5", true));
+    base_params["filter_bmod"].emplace<bool>(
+        pin->GetOrAddBoolean(block_name, "filter_bmod", true));
     auto use_ye = pin->GetOrAddBoolean("fluid", "Ye", false);
     provides_entropy = true;
     PARTHENON_REQUIRE_THROWS(use_ye,

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -49,6 +49,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   };
 
   bool needs_ye = false; // TODO(JMM) descriptive enough?
+  bool provides_entropy = false;
   names_t names;
   EOSBuilder::EOSType type;
   EOSBuilder::modifiers_t modifiers;
@@ -111,6 +112,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     base_params["use_sp5"].emplace<bool>(
         pin->GetOrAddBoolean(block_name, "use_sp5", true));
     auto use_ye = pin->GetOrAddBoolean("fluid", "Ye", false);
+    provides_entropy = true;
     PARTHENON_REQUIRE_THROWS(use_ye,
                              "\"StellarCollapse\" EOS requires that Ye be enabled!");
 #endif
@@ -156,6 +158,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("d.EOS", eos_device);
   params.Add("h.EOS", eos_host);
   params.Add("needs_ye", needs_ye);
+  params.Add("provides_entropy", provides_entropy);
 
   // Store eos params in case they're needed
   for (auto &name : names) {

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -251,15 +251,15 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   Real lrho_min_adiabat, lrho_max_adiabat; // rho bounds for adiabat
   Real h_min_sc;
   if (eos_type == "StellarCollapse") {
-    GetRhoBounds(eos_h, rho_min, rho_max, T_min, T_max, Ye, S, lrho_min_adiabat,
-                 lrho_max_adiabat);
+    Adiabats::GetRhoBounds(eos_h, rho_min, rho_max, T_min, T_max, Ye, S, lrho_min_adiabat,
+                           lrho_max_adiabat);
     temp_h.setRange(0, lrho_min_adiabat, lrho_max_adiabat, nsamps);
     const Real rho_min_adiabat = std::pow(10.0, lrho_min_adiabat);
     const Real rho_max_adiabat = std::pow(10.0, lrho_max_adiabat);
 
-    SampleRho(rho_h, lrho_min_adiabat, lrho_max_adiabat, nsamps);
-    ComputeAdiabats(rho_h, temp_h, eos_h, Ye, S, T_min, T_max, nsamps);
-    h_min_sc = MinEnthalpy(rho_h, temp_h, Ye, eos_h, nsamps);
+    Adiabats::SampleRho(rho_h, lrho_min_adiabat, lrho_max_adiabat, nsamps);
+    Adiabats::ComputeAdiabats(rho_h, temp_h, eos_h, Ye, S, T_min, T_max, nsamps);
+    h_min_sc = Adiabats::MinEnthalpy(rho_h, temp_h, Ye, eos_h, nsamps);
   }
   Real uphi_rmax;
   const Real hm1_rmax =

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -238,7 +238,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   RNGPool rng_pool(seed);
 
-  int nsamps = 180; // for adiabats 
+  int nsamps = 180; // for adiabats
   if (eos_type != "StellarCollapse") {
     nsamps = 1;
   }
@@ -252,7 +252,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real T_min = pmb->packages.Get("eos")->Param<Real>("T_min");
   const Real T_max = pmb->packages.Get("eos")->Param<Real>("T_max");
 
-  // adiabat calculation for table 
+  // adiabat calculation for table
   Real lrho_min_adiabat, lrho_max_adiabat; // rho bounds for adiabat
   Real h_min_sc;
   if (eos_type == "StellarCollapse") {

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -164,8 +164,9 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   // and the eos machinery needs to construct adiabats.
   const std::string eos_type = pin->GetString("eos", "type");
   const EosType eos_type_enum = (eos_type == "IdealGas") ? IdealGas : StellarCollapse;
-  PARTHENON_REQUIRE_THROWS(eos_type == "IdealGas" || eos_type == "StellarCollapse",
-                           "Torus setup only works with ideal gas or stellar collapse EOS");
+  PARTHENON_REQUIRE_THROWS(
+      eos_type == "IdealGas" || eos_type == "StellarCollapse",
+      "Torus setup only works with ideal gas or stellar collapse EOS");
   const Real gam = pin->GetReal("eos", "Gamma");
   const Real Cv = pin->GetReal("eos", "Cv");
 

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -269,7 +269,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
     SampleRho(rho_h, lrho_min_adiabat, lrho_max_adiabat, nsamps);
     ComputeAdiabats(rho_h, temp_h, eos_h, Ye, S, T_min, T_max, nsamps);
-    Real h_min_sc = MinEnthalpy(rho_h, temp_h, Ye, eos_h, nsamps);
+    h_min_sc = MinEnthalpy(rho_h, temp_h, Ye, eos_h, nsamps);
   }
   Real uphi_rmax;
   const Real hm1_rmax =
@@ -356,8 +356,6 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
                                : v(ieng, k, j, i);
         v(itmp, k, j, i) = eos.TemperatureFromDensityInternalEnergy(
             v(irho, k, j, i), v(ieng, k, j, i) / v(irho, k, j, i), lambda);
-        // std::printf("%e %e\n", v(itmp,k,j,i),
-        // temp_d.interpToReal(std::log10(v(irho,k,j,i))));
         v(iprs, k, j, i) = eos.PressureFromDensityTemperature(v(irho, k, j, i),
                                                               v(itmp, k, j, i), lambda);
         v(igm1, k, j, i) = eos.BulkModulusFromDensityTemperature(

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -165,7 +165,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const std::string eos_type = pin->GetString("eos", "type");
   const EosType eos_type_enum = (eos_type == "IdealGas") ? IdealGas : StellarCollapse;
   PARTHENON_REQUIRE_THROWS(eos_type == "IdealGas" || eos_type == "StellarCollapse",
-                           "Torus setup only works with ideal gas");
+                           "Torus setup only works with ideal gas or stellar collapse EOS");
   const Real gam = pin->GetReal("eos", "Gamma");
   const Real Cv = pin->GetReal("eos", "Cv");
 

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -317,9 +317,11 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
               const Real T = temp_d.interpToReal(std::log10(rho));
               Real lambda[2];
               lambda[0] = Ye;
+              //TODO: setting u incorrectly?
               Real u = eos.InternalEnergyFromDensityTemperature(rho, T, lambda) * rho;
 
               rho /= rho_rmax;
+              u /= u_rmax;
 
               Real ucon_bl[] = {0.0, 0.0, 0.0, uphi};
               Real gcov[4][4];
@@ -476,6 +478,10 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
     radiation::MomentPrim2Con(rc);
   }
 
+  free(rho_h);
+  free(rho_d);
+  free(temp_h);
+  free(temp_d);
   fixup::ApplyFloors(rc);
 }
 

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -177,8 +177,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const int nsub = pin->GetOrAddInteger("torus", "nsub", 1);
   const Real Ye = pin->GetOrAddReal("torus", "Ye", 0.5);
   Real S = pin->GetOrAddReal("torus", "entropy", 4.0);
-  Real lambda[2];
-  lambda[0] = Ye;
+  const int nsamps = pin->GetOrAddReal("eos", "nsamps_adiabat", 1);
 
   const Real a = pin->GetReal("geometry", "a");
   auto bl = Geometry::BoyerLindquist(a);
@@ -238,10 +237,6 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   RNGPool rng_pool(seed);
 
-  int nsamps = 180; // for adiabats
-  if (eos_type != "StellarCollapse") {
-    nsamps = 1;
-  }
   Spiner::DataBox rho_h(nsamps);
   Spiner::DataBox temp_h(nsamps);
 

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -637,7 +637,7 @@ void GetStateFromEnthalpy(const EOS &eos, const EosType eos_type, const Real hm1
     rho_out = std::pow(hm1 * (gam - 1.) / (kappa * gam), 1. / (gam - 1.));
     u_out = kappa * std::pow(rho_out, gam) / (gam - 1.) / rho_rmax;
     rho_out /= rho_rmax;
-  } else  { // StellarCollapse
+  } else { // StellarCollapse
     const int N = rho.size() - 1;
     const Real rho_min = std::pow(10.0, rho(0));
     const Real rho_max = std::pow(10.0, rho(N));

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -44,7 +44,7 @@ using namespace radiation;
 using Microphysics::Opacities;
 using Microphysics::EOS::EOS;
 
-// Hack to avoid using a string
+// If adding more EoS functionality, extend this and GetStateFromEnthalpy
 enum EosType { IdealGas, StellarCollapse };
 
 class GasRadTemperatureResidual {
@@ -72,7 +72,7 @@ class GasRadTemperatureResidual {
 
 /**
  * enthalpy residual for use with nuclear eos
- * computes fishbone enthalpy - nuclear EOS enthalpy to find
+ * computes fishbone enthalpy - EOS enthalpy to find
  * density, temperature given the correct enthalpy
  **/
 class EnthalpyResidual {
@@ -247,7 +247,6 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   Spiner::DataBox rho_h(nsamps);
   Spiner::DataBox temp_h(nsamps);
 
-  // compute adiabats
   // TODO: transition this to a package.
   const Real rho_min = pmb->packages.Get("eos")->Param<Real>("rho_min");
   const Real rho_max = pmb->packages.Get("eos")->Param<Real>("rho_max");
@@ -255,8 +254,11 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real lrho_max = std::log10(rho_max);
   const Real T_min = pmb->packages.Get("eos")->Param<Real>("T_min");
   const Real T_max = pmb->packages.Get("eos")->Param<Real>("T_max");
-  // Get adiabat databoxes on device
 
+  /**
+   * TODO(BLB): Once adiabat infrastructure can reproduce ideal torus 
+   * with given kappa, this hacky if(StellarCollapse) business can be cleaned
+   **/ 
   Real lrho_min_adiabat, lrho_max_adiabat; // rho bounds for adiabat
   Real h_min_sc;
   if (eos_type == "StellarCollapse") {

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -26,10 +26,12 @@
 #include "geometry/boyer_lindquist.hpp"
 #include "geometry/mckinney_gammie_ryan.hpp"
 #include "pgen/pgen.hpp"
+#include "phoebus_utils/adiabats.hpp"
 #include "phoebus_utils/reduction.hpp"
 #include "phoebus_utils/relativity_utils.hpp"
 #include "phoebus_utils/robust.hpp"
 #include "phoebus_utils/root_find.hpp"
+#include "phoebus_utils/unit_conversions.hpp"
 #include "radiation/radiation.hpp"
 
 typedef Kokkos::Random_XorShift64_Pool<> RNGPool;
@@ -63,6 +65,42 @@ class GasRadTemperatureResidual {
   const EOS &eos_;
   const RadiationType type_;
   const Real Ye_;
+};
+
+/**
+ * enthalpy residual for use with nuclear eos
+ * computes fishbone enthalpy - nuclear EOS enthalpy to find
+ * density, temperature given the correct enthalpy
+ **/
+class EnthalpyResidual {
+ public:
+  KOKKOS_FUNCTION
+  EnthalpyResidual(const Real hm1, const Spiner::DataBox T, const Real Ye,
+                   const Real h_min_sc, const EOS &eos)
+      : hm1_(hm1), T_(T), Ye_(Ye), h_min_sc_(h_min_sc), eos_(eos) {}
+
+  KOKKOS_INLINE_FUNCTION
+  Real operator()(const Real rho) {
+    const Real hsc = enthalpy_sc(rho);
+    return hm1_ - hsc + h_min_sc_; // hm1 = h_sc - h_min_sc
+  }
+
+ private:
+  const Real hm1_;
+  const Spiner::DataBox T_;
+  const Real Ye_;
+  const Real h_min_sc_;
+  const EOS &eos_;
+
+  KOKKOS_INLINE_FUNCTION
+  Real enthalpy_sc(const Real rho) {
+    Real lambda[2];
+    lambda[0] = Ye_;
+    const Real T = T_.interpToReal(std::log10(rho));
+    const Real P = eos_.PressureFromDensityTemperature(rho, T, lambda);
+    const Real e = eos_.InternalEnergyFromDensityTemperature(rho, T, lambda);
+    return 1.0 + e + P / rho;
+  }
 };
 
 enum class InitialRadiation { none, thermal };
@@ -116,8 +154,10 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   // The Fishbone solver needs to know about Ye
   // and the eos machinery needs to construct adiabats.
   const std::string eos_type = pin->GetString("eos", "type");
-  PARTHENON_REQUIRE_THROWS(eos_type == "IdealGas",
-                           "Torus setup only works with ideal gas");
+  // TODO: allow other eos
+  // TODO: Q: How to modify gam, cv = ...
+  //  PARTHENON_REQUIRE_THROWS(eos_type == "IdealGas",
+  //                           "Torus setup only works with ideal gas");
   const Real gam = pin->GetReal("eos", "Gamma");
   const Real Cv = pin->GetReal("eos", "Cv");
 
@@ -128,6 +168,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const int seed = pin->GetOrAddInteger("torus", "seed", time(NULL));
   const int nsub = pin->GetOrAddInteger("torus", "nsub", 1);
   const Real Ye = pin->GetOrAddReal("torus", "Ye", 0.5);
+  Real S = pin->GetOrAddReal("torus", "entropy", 4.0);
 
   const Real a = pin->GetReal("geometry", "a");
   auto bl = Geometry::BoyerLindquist(a);
@@ -142,6 +183,11 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   auto coords = pmb->coords;
   auto eos = pmb->packages.Get("eos")->Param<singularity::EOS>("d.EOS");
   auto floor = pmb->packages.Get("fixup")->Param<fixup::Floors>("floor");
+  auto &unit_conv =
+      pmb->packages.Get("phoebus")->Param<phoebus::UnitConversions>("unit_conv");
+
+  // logic to get the nuclear eos as needed.
+  bool provides_entropy = pmb->packages.Get("eos")->Param<bool>("provides_entropy");
 
   auto geom = Geometry::GetCoordinateSystem(rc);
 
@@ -183,15 +229,52 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   RNGPool rng_pool(seed);
 
+  // TODO: Make some databoxes for my adiabats
+  // Long term it might be nice to just compute adiabats for IdealGas too,
+  // once it is exposed in singularity-eos, to unify code
+  const int nsamps = 180; // TODO move this?
+                          // int as host. device obj as get on deivce.
+  Spiner::DataBox rho_d(Spiner::AllocationTarget::Device, nsamps);
+  Spiner::DataBox temp_d(Spiner::AllocationTarget::Device, nsamps);
+  // compute adiabats
+  // TODO: transition this to a package.
+  Real rho_min = pmb->packages.Get("eos")->Param<Real>("rho_min");
+  Real rho_max = pmb->packages.Get("eos")->Param<Real>("rho_max");
+  //rho_min *= unit_conv.GetMassDensityCodeToCGS();
+  //rho_max *= unit_conv.GetMassDensityCodeToCGS();
+  const Real lrho_min = std::log10(rho_min);
+  const Real lrho_max = std::log10(rho_max);
+  const Real T_min = pmb->packages.Get("eos")->Param<Real>("T_min");
+  const Real T_max = pmb->packages.Get("eos")->Param<Real>("T_max"); 
+  temp_d.setRange(0, lrho_min, lrho_max, nsamps);
+
+  // TODO: need to be smarter about rho bounds.
+  SampleRho(rho_d, lrho_min+1.5, lrho_max - 1.5, nsamps);
+  Real lambda[2];
+  lambda[0] = 0.1;
+  Real temp = eos.EntropyFromDensityTemperature( rho_min, T_min, lambda );
+  temp *= unit_conv.GetEntropyCodeToCGS();
+  S /= unit_conv.GetEntropyCGSToCode();
+  std::printf("%e %f\n", temp, S);
+  PARTHENON_REQUIRE( false, "stop!" );
+  ComputeAdiabats(rho_d, temp_d, eos, 0.1, S, T_min, T_max, nsamps);
+  //const Real h_min_sc = MinEnthalpy(rho_d, temp_d, Ye, eos, nsamps);
+
   Real uphi_rmax;
   const Real hm1_rmax =
       std::exp(log_enthalpy(rmax, 0.5 * M_PI, a, rin, angular_mom, uphi_rmax)) - 1.0;
 
   // TODO(JMM): This will need to change when we move to realistic
   // EOS's for the torus.
-  const Real rho_rmax = std::pow(hm1_rmax * (gam - 1.) / (kappa * gam), 1. / (gam - 1.));
+  //EnthalpyResidual res_h(hm1_rmax, temp_d, Ye, h_min_sc, eos);
+  //root_find::RootFind rf;
+  //const Real guess_h = 0.5 * std::pow(10.0, lrho_max - lrho_min);
+  //const Real rho_rmax = rf.regula_falsi(res_h, rho_min, rho_max, 1e-6 * guess_h, guess_h);
+   const Real rho_rmax = std::pow(hm1_rmax * (gam - 1.) / (kappa * gam), 1. / (gam
+   - 1.));
   const Real u_rmax = kappa * std::pow(rho_rmax, gam) / (gam - 1.) / rho_rmax;
 
+  PARTHENON_REQUIRE(false, "stop the shpw");
   pmb->par_for(
       "Phoebus::ProblemGenerator::Torus", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
@@ -215,8 +298,10 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
             if (r > rin) lnh = log_enthalpy(r, th, a, rin, angular_mom, uphi);
 
             if (lnh > 0.0) {
+              // TODO: need to get rho, T, from hm1. The rest follow
               Real hm1 = std::exp(lnh) - 1.;
               Real rho = std::pow(hm1 * (gam - 1.) / (kappa * gam), 1. / (gam - 1.));
+              // u is density or specific? I think specific
               Real u = kappa * std::pow(rho, gam) / (gam - 1.) / rho_rmax;
 
               rho /= rho_rmax;
@@ -412,6 +497,7 @@ void ProblemModifier(ParameterInput *pin) {
   const bool do_rad = pin->GetOrAddBoolean("physics", "rad", false);
   if (do_rad) {
     const std::string eos_type = pin->GetString("eos", "type");
+    // TODO: allow other eos
     if (eos_type == "IdealGas") {
       const Real Gamma = pin->GetReal("eos", "Gamma");
       PARTHENON_WARN("Resetting Cv assuming Ye = 0.5!");

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -34,7 +34,7 @@ inline void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
                          Real &lrho_min_new, Real &lrho_max_new) {
 
   // adjust bounds slightly to avoid edges
-  const Real ADJUST = 0.01; //0.01
+  const Real ADJUST = 0.01; // 0.01
   root_find::RootFind root_find;
   root_find::RootFindStatus status;
   Real lambda[2];

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -56,7 +56,6 @@ void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
     lrho_max_new = rho_max;
   };
   lrho_max_new = std::log10(lrho_max_new);
-  std::printf("%e %e\n", lrho_min_new, lrho_max_new);
 }
 
 template <typename D>
@@ -82,7 +81,6 @@ void ComputeAdiabats(D rho, D temp, const EOS &eos, const Real Ye, const Real S0
         lambda[0] = Ye;
 
         auto target = [&](const Real T) {
-          //std::printf("%e %e\n", Rho, T);
           return eos.EntropyFromDensityTemperature(Rho, T, lambda) - S0;
         };
 

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -94,15 +94,15 @@ void ComputeAdiabats(D rho, D temp, const EOS &eos, const Real Ye, const Real S0
  * Find the minimum enthalpy along as adiabat as computed above
  **/
 template <typename D, typename EOS>
-Real MinEnthalpy(D rho, D temp, const Real Ye, const EOS &eos, const int n_samps) {
+Real MinEnthalpy(D lrho, D temp, const Real Ye, const EOS &eos, const int n_samps) {
   Real min_h = 0.0;
   Real min_enthalpy = 1e30;
   parthenon::par_reduce(
-      parthenon::loop_pattern_mdrange_tag, "Adiabats::MinEnthalpy", DevExecSpace(), 0,
-      n_samps, 0, n_samps,
-      KOKKOS_LAMBDA(const int i, const int j, Real &min_enthalpy) {
-        const Real Rho = std::pow(10.0, rho(i));
-        const Real T = temp(i);
+      parthenon::loop_pattern_flatrange_tag, "Adiabats::MinEnthalpy", DevExecSpace(), 0,
+      n_samps,
+      KOKKOS_LAMBDA(const int i, Real &min_enthalpy) {
+        const Real Rho = std::pow(10.0, lrho(i));
+        const Real T = temp.interpToReal(std::log10(Rho));
         Real lambda[2];
         lambda[0] = Ye;
 

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -23,11 +23,11 @@
 #include "phoebus_utils/root_find.hpp"
 
 // a namespace?
+using Microphysics::EOS::EOS;
 
-template <typename EOS>
-void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
-                  const Real T_min, const Real T_max, const Real Ye, const Real S0,
-                  Real &lrho_min_new, Real &lrho_max_new) {
+inline void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
+                         const Real T_min, const Real T_max, const Real Ye, const Real S0,
+                         Real &lrho_min_new, Real &lrho_max_new) {
 
   root_find::RootFind root_find;
   root_find::RootFindStatus status;
@@ -63,8 +63,8 @@ void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
 }
 
 // sample log rho
-template <typename D>
-void SampleRho(D lrho, const Real lrho_min, const Real lrho_max, const int n_samps) {
+inline void SampleRho(Spiner::DataBox lrho, const Real lrho_min, const Real lrho_max,
+                      const int n_samps) {
   const Real dlrho = (lrho_max - lrho_min) / n_samps;
 
   parthenon::par_for(
@@ -75,9 +75,9 @@ void SampleRho(D lrho, const Real lrho_min, const Real lrho_max, const int n_sam
 /**
  * Given Ye and a target entropy, compute density and temperature of constant entropy
  **/
-template <typename D, typename EOS>
-void ComputeAdiabats(D lrho, D temp, const EOS &eos, const Real Ye, const Real S0,
-                     const Real T_min, const Real T_max, const int n_samps) {
+inline void ComputeAdiabats(Spiner::DataBox lrho, Spiner::DataBox temp, const EOS &eos,
+                            const Real Ye, const Real S0, const Real T_min,
+                            const Real T_max, const int n_samps) {
 
   const Real guess0 = (T_max - T_min) / 2.0;
 
@@ -101,8 +101,8 @@ void ComputeAdiabats(D lrho, D temp, const EOS &eos, const Real Ye, const Real S
 /**
  * Find the minimum enthalpy along an adiabat as computed above
  **/
-template <typename D, typename EOS>
-Real MinEnthalpy(D lrho, D temp, const Real Ye, const EOS &eos, const int n_samps) {
+inline Real MinEnthalpy(Spiner::DataBox lrho, Spiner::DataBox temp, const Real Ye,
+                        const EOS &eos, const int n_samps) {
   Real min_h = 0.0;
   Real min_enthalpy = 1e30;
   parthenon::par_reduce(

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -1,0 +1,62 @@
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+#ifndef PHOEBUS_UTILS_ADIABATS_HPP_
+#define PHOEBUS_UTILS_ADIABATS_HPP_
+
+#include <globals.hpp>
+#include <kokkos_abstraction.hpp>
+
+#include <utils/error_checking.hpp>
+
+#include "phoebus_utils/root_find.hpp"
+
+// a namespace?
+using singularity::EOS;
+
+template <typename D>
+void SampleRho(D rho, const Real rho_min, const Real rho_max, const int n_samps) {
+  const Real drho = (rho_max - rho_min) / n_samps;
+
+  parthenon::par_for( 
+      DEFAULT_LOOP_PATTERN, "Adiabats::SampleRho", DevExecSpace(), 0, n_samps, 
+      KOKKOS_LAMBDA(const int i) {
+        rho(i) = rho_min + i * drho;
+      });
+}
+
+template <typename D>
+void ComputeAdiabat(D rho, D temp, EOS &eos, const Real Ye, const Real S0, 
+    const Real T_min, const Real T_max, const int n_samps) {
+
+
+  const Real guess0 = (T_max - T_min) / 2.0;
+
+  parthenon::par_for( 
+      DEFAULT_LOOP_PATTERN, "Adiabats::ComputeAdiabats", DevExecSpace(), 0, n_samps, 
+      KOKKOS_LAMBDA(const int i) {
+
+        const Real rho = Rho(i);
+        Real lambda[2]; 
+        lambda[0] = Ye;
+
+        Real target = [&](const Real T) {
+          return eos.EntropyFromDensityTemperature(rho, T, lambda) - S0;
+        };
+
+        const Real guess = guess0;
+        root_find::RootFind root_find;
+        temp(i) = root_find.regula_falsi(target, T_min, T_max, 1.e-6 * guess, guess);
+      });
+}
+#endif // PHOEBUS_UTILS_ADIABATS_HPP_

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -34,7 +34,7 @@ inline void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
                          Real &lrho_min_new, Real &lrho_max_new) {
 
   // adjust bounds slightly to avoid edges
-  const Real ADJUST = 0.01; // 0.01
+  constexpr Real ADJUST = 0.01;
   root_find::RootFind root_find;
   root_find::RootFindStatus status;
   Real lambda[2];

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -69,7 +69,9 @@ inline void SampleRho(Spiner::DataBox lrho, const Real lrho_min, const Real lrho
                       const int n_samps) {
   const Real dlrho = (lrho_max - lrho_min) / n_samps;
 
-  for ( int i = 0; i < n_samps; i++ ) { lrho(i) = lrho_min + i * dlrho; }
+  for (int i = 0; i < n_samps; i++) {
+    lrho(i) = lrho_min + i * dlrho;
+  }
 }
 
 /**
@@ -82,7 +84,7 @@ inline void ComputeAdiabats(Spiner::DataBox lrho, Spiner::DataBox temp, const EO
 
   const Real guess0 = (T_max - T_min) / 2.0;
 
-  for ( int i = 0; i < n_samps; i++ ) { 
+  for (int i = 0; i < n_samps; i++) {
     const Real Rho = std::pow(10.0, lrho(i));
     Real lambda[2];
     lambda[0] = Ye;
@@ -94,7 +96,7 @@ inline void ComputeAdiabats(Spiner::DataBox lrho, Spiner::DataBox temp, const EO
     const Real guess = guess0;
     root_find::RootFind root_find;
     temp(i) = root_find.regula_falsi(target, T_min, T_max, 1.e-10 * guess, guess);
-      }
+  }
 }
 
 /**
@@ -104,7 +106,7 @@ template <typename EOS>
 inline Real MinEnthalpy(Spiner::DataBox lrho, Spiner::DataBox temp, const Real Ye,
                         const EOS &eos, const int n_samps) {
   Real min_enthalpy = 1e30;
-  for ( int i = 0; i < n_samps; i++ ) { 
+  for (int i = 0; i < n_samps; i++) {
     const Real Rho = std::pow(10.0, lrho(i));
     const Real T = temp.interpToReal(lrho(i));
     Real lambda[2];
@@ -118,7 +120,7 @@ inline Real MinEnthalpy(Spiner::DataBox lrho, Spiner::DataBox temp, const Real Y
 
     const Real h = enthalpy_sc();
     min_enthalpy = (h < min_enthalpy) ? h : min_enthalpy;
-    }
+  }
   return min_enthalpy;
 }
 #endif // PHOEBUS_UTILS_ADIABATS_HPP_

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -59,16 +59,16 @@ void GetRhoBounds(const EOS &eos, const Real rho_min, const Real rho_max,
 }
 
 template <typename D>
-void SampleRho(D rho, const Real rho_min, const Real rho_max, const int n_samps) {
-  const Real drho = (rho_max - rho_min) / n_samps;
+void SampleRho(D lrho, const Real lrho_min, const Real lrho_max, const int n_samps) {
+  const Real dlrho = (lrho_max - lrho_min) / n_samps;
 
   parthenon::par_for(
       parthenon::loop_pattern_flatrange_tag, "Adiabats::SampleRho", DevExecSpace(), 0,
-      n_samps, KOKKOS_LAMBDA(const int i) { rho(i) = rho_min + i * drho; });
+      n_samps, KOKKOS_LAMBDA(const int i) { lrho(i) = lrho_min + i * dlrho; });
 }
 
 template <typename D, typename EOS>
-void ComputeAdiabats(D rho, D temp, const EOS &eos, const Real Ye, const Real S0,
+void ComputeAdiabats(D lrho, D temp, const EOS &eos, const Real Ye, const Real S0,
                      const Real T_min, const Real T_max, const int n_samps) {
 
   const Real guess0 = (T_max - T_min) / 2.0;
@@ -76,7 +76,7 @@ void ComputeAdiabats(D rho, D temp, const EOS &eos, const Real Ye, const Real S0
   parthenon::par_for(
       parthenon::loop_pattern_flatrange_tag, "Adiabats::ComputeAdiabats", DevExecSpace(),
       0, n_samps, KOKKOS_LAMBDA(const int i) {
-        const Real Rho = std::pow(10.0, rho(i));
+        const Real Rho = std::pow(10.0, lrho(i));
         Real lambda[2];
         lambda[0] = Ye;
 

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -25,7 +25,8 @@
 #include "microphysics/eos_phoebus/eos_phoebus.hpp"
 #include "phoebus_utils/root_find.hpp"
 
-// a namespace?
+namespace Adiabats {
+
 using Microphysics::EOS::EOS;
 
 template <typename EOS>
@@ -129,4 +130,6 @@ inline Real MinEnthalpy(Spiner::DataBox lrho, Spiner::DataBox temp, const Real Y
   }
   return min_enthalpy;
 }
+
+} // namespace Adiabats
 #endif // PHOEBUS_UTILS_ADIABATS_HPP_

--- a/src/phoebus_utils/root_find.hpp
+++ b/src/phoebus_utils/root_find.hpp
@@ -112,7 +112,7 @@ struct RootFind {
                                            RootFindStatus *status = nullptr) {
     Real ya, yb;
     refine_bracket(func, guess, a, b, ya, yb);
-    if (!check_bracket(a, b, ya, yb)) {
+    if (!check_bracket(a, b, ya, yb, status)) {
       if (status == nullptr) {
         PARTHENON_FAIL("Aborting with unbracketed root.");
       } else {
@@ -177,7 +177,7 @@ struct RootFind {
 
     Real ya, yb;
     refine_bracket(func, guess, a, b, ya, yb);
-    if (!check_bracket(a, b, ya, yb)) {
+    if (!check_bracket(a, b, ya, yb, status)) {
       if (status == nullptr) {
         PARTHENON_FAIL("Aborting with unbracketed root.");
       } else {
@@ -226,7 +226,7 @@ struct RootFind {
 
     Real ya = func(a);
     Real yb = func(b);
-    if (!check_bracket(a, b, ya, yb)) {
+    if (!check_bracket(a, b, ya, yb, status)) {
       if (status == nullptr) {
         PARTHENON_FAIL("Aborting with unbracketed root.");
       } else {

--- a/src/phoebus_utils/unit_conversions.cpp
+++ b/src/phoebus_utils/unit_conversions.cpp
@@ -35,11 +35,17 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
     int geom_mass_g_exists = pin->DoesParameterExist("units", "geom_mass_g");
     int geom_mass_msun_exists = pin->DoesParameterExist("units", "geom_mass_msun");
     int geom_length_cm_exists = pin->DoesParameterExist("units", "geom_length_cm");
+    int fluid_density_g_exists = pin->DoesParameterExist("units", "fluid_density_g");
+    int fluid_mass_g_exists = pin->DoesParameterExist("units", "fluid_mass_g");
 
     PARTHENON_REQUIRE(
         geom_mass_g_exists + geom_mass_msun_exists + geom_length_cm_exists == 1,
         "Must provide exactly one of geom_mass_g, geom_mass_msun, "
         "geom_length_cm!");
+
+    PARTHENON_REQUIRE(
+        fluid_mass_g_exists + fluid_density_g_exists == 1,
+        "Cannot provide both fluid_mass_g and fluid_density_g");
 
     if (geom_mass_g_exists) {
       Real geom_mass_ = pin->GetReal("units", "geom_mass_g");
@@ -55,7 +61,14 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
       length_ = pin->GetReal("units", "geom_length_cm");
     }
 
-    mass_ = pin->GetReal("units", "fluid_mass_g");
+    if (fluid_mass_g_exists) {
+      mass_ = pin->GetReal("units", "fluid_mass_g");
+    }
+
+    if (fluid_density_g_exists) {
+      mass_ = length_ * length_ * length_ * pin->GetReal("units", "fluid_density_g");
+      std::printf("mass_ = %e\n", mass_);
+    }
   }
 
   time_ = length_ / pc.c;

--- a/src/phoebus_utils/unit_conversions.cpp
+++ b/src/phoebus_utils/unit_conversions.cpp
@@ -66,7 +66,6 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
 
     if (fluid_density_g_exists) {
       mass_ = length_ * length_ * length_ * pin->GetReal("units", "fluid_density_g");
-      std::printf("mass_ = %e\n", mass_);
     }
   }
 

--- a/src/phoebus_utils/unit_conversions.cpp
+++ b/src/phoebus_utils/unit_conversions.cpp
@@ -43,9 +43,8 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
         "Must provide exactly one of geom_mass_g, geom_mass_msun, "
         "geom_length_cm!");
 
-    PARTHENON_REQUIRE(
-        fluid_mass_g_exists + fluid_density_g_exists == 1,
-        "Cannot provide both fluid_mass_g and fluid_density_g");
+    PARTHENON_REQUIRE(fluid_mass_g_exists + fluid_density_g_exists == 1,
+                      "Cannot provide both fluid_mass_g and fluid_density_g");
 
     if (geom_mass_g_exists) {
       Real geom_mass_ = pin->GetReal("units", "geom_mass_g");

--- a/src/phoebus_utils/unit_conversions.cpp
+++ b/src/phoebus_utils/unit_conversions.cpp
@@ -35,7 +35,7 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
     int geom_mass_g_exists = pin->DoesParameterExist("units", "geom_mass_g");
     int geom_mass_msun_exists = pin->DoesParameterExist("units", "geom_mass_msun");
     int geom_length_cm_exists = pin->DoesParameterExist("units", "geom_length_cm");
-    int fluid_density_g_exists = pin->DoesParameterExist("units", "fluid_density_g");
+    int fluid_density_cgs_exists = pin->DoesParameterExist("units", "fluid_density_cgs");
     int fluid_mass_g_exists = pin->DoesParameterExist("units", "fluid_mass_g");
 
     PARTHENON_REQUIRE(
@@ -43,8 +43,8 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
         "Must provide exactly one of geom_mass_g, geom_mass_msun, "
         "geom_length_cm!");
 
-    PARTHENON_REQUIRE(fluid_mass_g_exists + fluid_density_g_exists == 1,
-                      "Cannot provide both fluid_mass_g and fluid_density_g");
+    PARTHENON_REQUIRE(fluid_mass_g_exists + fluid_density_cgs_exists == 1,
+                      "Cannot provide both fluid_mass_g and fluid_density_cgs");
 
     if (geom_mass_g_exists) {
       Real geom_mass_ = pin->GetReal("units", "geom_mass_g");
@@ -64,8 +64,8 @@ UnitConversions::UnitConversions(ParameterInput *pin) {
       mass_ = pin->GetReal("units", "fluid_mass_g");
     }
 
-    if (fluid_density_g_exists) {
-      mass_ = length_ * length_ * length_ * pin->GetReal("units", "fluid_density_g");
+    if (fluid_density_cgs_exists) {
+      mass_ = length_ * length_ * length_ * pin->GetReal("units", "fluid_density_cgs");
     }
   }
 

--- a/src/phoebus_utils/unit_conversions.hpp
+++ b/src/phoebus_utils/unit_conversions.hpp
@@ -50,6 +50,9 @@ class UnitConversions {
   Real GetTemperatureCodeToCGS() const { return temperature_; }
   Real GetTemperatureCGSToCode() const { return 1. / temperature_; }
 
+  Real GetEntropyCodeToCGS() const { return energy_ / temperature_ / mass_; }
+  Real GetEntropyCGSToCode() const { return mass_ * temperature_ / energy_; }
+
  private:
   bool scale_free_;
   Real mass_;

--- a/src/phoebus_utils/unit_conversions.hpp
+++ b/src/phoebus_utils/unit_conversions.hpp
@@ -50,8 +50,8 @@ class UnitConversions {
   Real GetTemperatureCodeToCGS() const { return temperature_; }
   Real GetTemperatureCGSToCode() const { return 1. / temperature_; }
 
-  Real GetEntropyCodeToCGS() const { return energy_ / temperature_; }
-  Real GetEntropyCGSToCode() const { return temperature_ / energy_; }
+  Real GetEntropyCodeToCGS() const { return (energy_ / mass_)/ temperature_; }
+  Real GetEntropyCGSToCode() const { return mass_ * temperature_ / energy_; }
 
  private:
   bool scale_free_;

--- a/src/phoebus_utils/unit_conversions.hpp
+++ b/src/phoebus_utils/unit_conversions.hpp
@@ -50,8 +50,8 @@ class UnitConversions {
   Real GetTemperatureCodeToCGS() const { return temperature_; }
   Real GetTemperatureCGSToCode() const { return 1. / temperature_; }
 
-  Real GetEntropyCodeToCGS() const { return energy_ / temperature_ / mass_; }
-  Real GetEntropyCGSToCode() const { return mass_ * temperature_ / energy_; }
+  Real GetEntropyCodeToCGS() const { return energy_ / temperature_; }
+  Real GetEntropyCGSToCode() const { return temperature_ / energy_; }
 
  private:
   bool scale_free_;

--- a/src/phoebus_utils/unit_conversions.hpp
+++ b/src/phoebus_utils/unit_conversions.hpp
@@ -50,7 +50,7 @@ class UnitConversions {
   Real GetTemperatureCodeToCGS() const { return temperature_; }
   Real GetTemperatureCGSToCode() const { return 1. / temperature_; }
 
-  Real GetEntropyCodeToCGS() const { return (energy_ / mass_)/ temperature_; }
+  Real GetEntropyCodeToCGS() const { return (energy_ / mass_) / temperature_; }
   Real GetEntropyCGSToCode() const { return mass_ * temperature_ / energy_; }
 
  private:

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -39,6 +39,10 @@ catch_discover_tests(phoebus_unit_tests
   TEST_SPEC "[relativity_utils]" TEST_PREFIX "relativity_utils:")
 catch_discover_tests(phoebus_unit_tests 
   TEST_SPEC "[radiation]" TEST_PREFIX "radiation:")
+if(PHOEBUS_ENABLE_DOWNLOADS)
+  catch_discover_tests(phoebus_unit_tests 
+    TEST_SPEC "[compute_adiabats]" TEST_PREFIX "adiabats:")
+endif()
 
 # Currently integration and regression tests 
 # are not integrated into the cmake build system 

--- a/tst/unit/phoebus_utils/CMakeLists.txt
+++ b/tst/unit/phoebus_utils/CMakeLists.txt
@@ -10,6 +10,30 @@
 # prepare derivative works, distribute copies to the public, perform
 # publicly and display publicly, and to permit others to do so.
 
+include(FetchContent)
+
+if(PHOEBUS_ENABLE_DOWNLOADS)
+  set(FN "Hempel_SFHoEOS_rho222_temp180_ye60_version_1.1_20120817.h5.bz2")
+  message(STATUS "Fetching SFHo table as needed (this may take a moment..)")
+  FetchContent_Declare(table
+    #URL https://stellarcollapse.org/~evanoc/Hempel_SFHoEOS_rho222_temp180_ye60_version_1.1_20120817.h5.bz2
+    URL https://stellarcollapse.org/~evanoc/${FN}
+    URL_HASH SHA256=5a76c40dcff0f027fb79a7fd46fa1c867f7e592428ec01796e8e13800f694154
+    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/table_dir
+    DOWNLOAD_NO_EXTRACT true
+  )
+  FetchContent_MakeAvailable(table)
+  
+  if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/table_dir/${FN})
+  message(STATUS "Extracting table (this will take a moment...)")
+  execute_process(
+    COMMAND bzip2 -d 
+    ${CMAKE_CURRENT_BINARY_DIR}/table_dir/${FN}
+    #OUTPUT_VARIABLE extract_status
+    )
+  endif()
+endif()
+
 add_library(phoebus_utils_unit_tests OBJECT
   test_relativity_utils.cpp
   test_adiabats.cpp

--- a/tst/unit/phoebus_utils/CMakeLists.txt
+++ b/tst/unit/phoebus_utils/CMakeLists.txt
@@ -12,6 +12,7 @@
 
 add_library(phoebus_utils_unit_tests OBJECT
   test_relativity_utils.cpp
+  test_adiabats.cpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../src/geometry/geometry.cpp
 )

--- a/tst/unit/phoebus_utils/test_adiabats.cpp
+++ b/tst/unit/phoebus_utils/test_adiabats.cpp
@@ -34,7 +34,7 @@
 // Relativity utils
 #include "phoebus_utils/adiabats.hpp"
 
-// using namespace phoebus;
+using namespace Adiabats;
 using singularity::StellarCollapse;
 
 TEST_CASE("ADIABATS", "[compute_adiabats]") {

--- a/tst/unit/phoebus_utils/test_adiabats.cpp
+++ b/tst/unit/phoebus_utils/test_adiabats.cpp
@@ -11,9 +11,9 @@
 // distribute copies to the public, perform publicly and display
 // publicly, and to permit others to do so.
 
-
 // stdlib includes
 #include <cmath>
+#include <limits>
 
 // external includes
 #include "catch2/catch.hpp"
@@ -26,16 +26,62 @@
 #include <kokkos_abstraction.hpp>
 #include <parameter_input.hpp>
 
+#include <spiner/databox.hpp>
+
 // Test utils
 #include "test_utils.hpp"
 
 // Relativity utils
 #include "phoebus_utils/adiabats.hpp"
 
-using namespace phoebus;
+// using namespace phoebus;
 using singularity::StellarCollapse;
 
 TEST_CASE("ADIABATS", "[compute_adiabats]") {
-  StellarCollapse eos("~/scratch/sfho_table.h5"); // TODO: update
-  REQUIRE(true);
+  GIVEN("A stellar collapse table") {
+    std::string filename = "./unit/phoebus_utils/table_dir/"
+                           "Hempel_SFHoEOS_rho222_temp180_ye60_version_1.1_20120817.h5";
+    StellarCollapse eos(filename);
+
+    const int nsamps = 180;
+    Spiner::DataBox rho_d(Spiner::AllocationTarget::Device, nsamps);
+    Spiner::DataBox temp_d(Spiner::AllocationTarget::Device, nsamps);
+    const Real lrho_min = eos.lRhoMin();
+    const Real lrho_max = eos.lRhoMax();
+    const Real T_min = std::pow(10.0, eos.lTMin());
+    const Real T_max = std::pow(10.0, eos.lTMax());
+
+    THEN("We can compute adiabats") {
+      /**
+       * Sample rho. For this adiabat, we do not go to the table upper limit
+       * May need generalization in the future [TODO(BLB)]
+       **/
+      SampleRho(rho_d, lrho_min, lrho_max - 1.5, nsamps);
+
+      const Real Ye = 0.1;
+      const Real S0 = 20.0;
+      ComputeAdiabats(rho_d, temp_d, eos, Ye, S0, T_min, T_max, nsamps);
+
+      AND_THEN("We verify that the adiabats produce the original entropy") {
+        // Given the adiabats, we should be able to get back the original entropy S0
+        int n_wrong = 1;
+        Kokkos::parallel_reduce(
+            "get n_wrong (adiabats)", nsamps,
+            KOKKOS_LAMBDA(const int i, int &update) {
+              Real lambda[2];
+              lambda[0] = Ye;
+              const Real rho = std::pow(10.0, rho_d(i));
+              const Real S_i = eos.EntropyFromDensityTemperature(rho, temp_d(i), lambda);
+              if (!SoftEquiv(S_i, S0, 1.e-6, false)) {
+                update += 1;
+              }
+            },
+            n_wrong);
+
+        free(rho_d);
+        free(temp_d);
+        REQUIRE(n_wrong == 0);
+      }
+    }
+  }
 }

--- a/tst/unit/phoebus_utils/test_adiabats.cpp
+++ b/tst/unit/phoebus_utils/test_adiabats.cpp
@@ -48,18 +48,24 @@ TEST_CASE("ADIABATS", "[compute_adiabats]") {
     Spiner::DataBox temp_d(Spiner::AllocationTarget::Device, nsamps);
     const Real lrho_min = eos.lRhoMin();
     const Real lrho_max = eos.lRhoMax();
+    const Real rho_min = std::pow(10.0, lrho_min);
+    const Real rho_max = std::pow(10.0, lrho_max);
     const Real T_min = std::pow(10.0, eos.lTMin());
     const Real T_max = std::pow(10.0, eos.lTMax());
+
+    const Real Ye = 0.1;
+    const Real S0 = 20.0;
 
     THEN("We can compute adiabats") {
       /**
        * Sample rho. For this adiabat, we do not go to the table upper limit
        * May need generalization in the future [TODO(BLB)]
        **/
-      SampleRho(rho_d, lrho_min, lrho_max - 1.5, nsamps);
+      Real lrho_min_adiabat, lrho_max_adiabat; // rho bounds for adiabat
+      GetRhoBounds(eos, rho_min, rho_max, T_min, T_max, Ye, S0, 
+                   lrho_min_adiabat, lrho_max_adiabat);
+      SampleRho(rho_d, lrho_min_adiabat, lrho_max_adiabat, nsamps);
 
-      const Real Ye = 0.1;
-      const Real S0 = 20.0;
       ComputeAdiabats(rho_d, temp_d, eos, Ye, S0, T_min, T_max, nsamps);
 
       AND_THEN("We verify that the adiabats produce the original entropy") {

--- a/tst/unit/phoebus_utils/test_adiabats.cpp
+++ b/tst/unit/phoebus_utils/test_adiabats.cpp
@@ -1,0 +1,41 @@
+// © 2023. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+
+
+// stdlib includes
+#include <cmath>
+
+// external includes
+#include "catch2/catch.hpp"
+#include <Kokkos_Core.hpp>
+#include <singularity-eos/eos/eos.hpp>
+
+// parthenon includes
+#include <coordinates/coordinates.hpp>
+#include <defs.hpp>
+#include <kokkos_abstraction.hpp>
+#include <parameter_input.hpp>
+
+// Test utils
+#include "test_utils.hpp"
+
+// Relativity utils
+#include "phoebus_utils/adiabats.hpp"
+
+using namespace phoebus;
+using singularity::StellarCollapse;
+
+TEST_CASE("ADIABATS", "[compute_adiabats]") {
+  StellarCollapse eos("~/scratch/sfho_table.h5"); // TODO: update
+  REQUIRE(true);
+}

--- a/tst/unit/phoebus_utils/test_adiabats.cpp
+++ b/tst/unit/phoebus_utils/test_adiabats.cpp
@@ -41,12 +41,12 @@ TEST_CASE("ADIABATS", "[compute_adiabats]") {
   GIVEN("A stellar collapse table") {
     std::string filename = "./unit/phoebus_utils/table_dir/"
                            "Hempel_SFHoEOS_rho222_temp180_ye60_version_1.1_20120817.h5";
-    StellarCollapse eos(filename);
+    StellarCollapse eos(filename, false, false);
 
     const int nsamps = 180;
     Spiner::DataBox rho_d(Spiner::AllocationTarget::Device, nsamps);
     Spiner::DataBox temp_d(Spiner::AllocationTarget::Device, nsamps);
-    const Real lrho_min = eos.lRhoMin();
+    const Real lrho_min = eos.lRhoMin() - 0.5;
     const Real lrho_max = eos.lRhoMax();
     const Real rho_min = std::pow(10.0, lrho_min);
     const Real rho_max = std::pow(10.0, lrho_max);
@@ -62,8 +62,9 @@ TEST_CASE("ADIABATS", "[compute_adiabats]") {
        * May need generalization in the future [TODO(BLB)]
        **/
       Real lrho_min_adiabat, lrho_max_adiabat; // rho bounds for adiabat
-      GetRhoBounds(eos, rho_min, rho_max, T_min, T_max, Ye, S0, 
-                   lrho_min_adiabat, lrho_max_adiabat);
+      GetRhoBounds(eos, rho_min, rho_max, T_min, T_max, Ye, S0, lrho_min_adiabat,
+                   lrho_max_adiabat);
+      std::printf("%e %e\n", lrho_min_adiabat, lrho_max_adiabat);
       SampleRho(rho_d, lrho_min_adiabat, lrho_max_adiabat, nsamps);
 
       ComputeAdiabats(rho_d, temp_d, eos, Ye, S0, T_min, T_max, nsamps);

--- a/tst/unit/phoebus_utils/test_adiabats.cpp
+++ b/tst/unit/phoebus_utils/test_adiabats.cpp
@@ -46,7 +46,7 @@ TEST_CASE("ADIABATS", "[compute_adiabats]") {
     const int nsamps = 180;
     Spiner::DataBox rho_d(Spiner::AllocationTarget::Device, nsamps);
     Spiner::DataBox temp_d(Spiner::AllocationTarget::Device, nsamps);
-    const Real lrho_min = eos.lRhoMin() - 0.5;
+    const Real lrho_min = eos.lRhoMin();
     const Real lrho_max = eos.lRhoMax();
     const Real rho_min = std::pow(10.0, lrho_min);
     const Real rho_max = std::pow(10.0, lrho_max);
@@ -57,14 +57,9 @@ TEST_CASE("ADIABATS", "[compute_adiabats]") {
     const Real S0 = 20.0;
 
     THEN("We can compute adiabats") {
-      /**
-       * Sample rho. For this adiabat, we do not go to the table upper limit
-       * May need generalization in the future [TODO(BLB)]
-       **/
       Real lrho_min_adiabat, lrho_max_adiabat; // rho bounds for adiabat
       GetRhoBounds(eos, rho_min, rho_max, T_min, T_max, Ye, S0, lrho_min_adiabat,
                    lrho_max_adiabat);
-      std::printf("%e %e\n", lrho_min_adiabat, lrho_max_adiabat);
       SampleRho(rho_d, lrho_min_adiabat, lrho_max_adiabat, nsamps);
 
       ComputeAdiabats(rho_d, temp_d, eos, Ye, S0, T_min, T_max, nsamps);


### PR DESCRIPTION
This PR adds necessary functionality to get the torus problem working with StellarCollapse EoS.

## PR Summary
I add the following functionalities:
- `adiabats.hpp` which includes necessary functions to compute adiabats from the table given S, Ye.
  - A unit test for this has been added.
- In the torus pgen, I pull in the various quantities needed (adiabatic S, Ye, table bounds). The calculations for `rho` and `u` are replaced by `GetStateFromEnthalpy` which returns `rho` and `u` for either the ideal gas or stellar collapse EoS.

Misc change: bug found in `root_find` where `status` was not passed through correctly and it complained when the root find failed even when status was passed in.

## TODO:
- @brryan When you have time, can you verify that this change does not break things for your applications? (Note: You may need to update `singularity-eos` to its latest and checkout `jhp/entropy`.
- I would like to unify the adiabat framework to work for the ideal gas as well, but I need to reason around this `kappa`.
- @brryan Do you know of anything immediately obvious that I would need to change for this to work with radiation? I haven't modified any of those parts of the pgen yet.
- This requires the `jhp/entropy` branch of `singularity-eos`. Once that is through I need to update the used version of singularity to latest commit. @jonahm-LANL I tried committing `singularity-eos` to latest but I think it did not stick. What is the way to do this?


## PR Checklist

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
