### PR TITLE
Fix MC issue

### DIFF
--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -278,21 +278,21 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
             z(m) = minx_k + (k - kb.s + 0.5) * dx_k;
 
             // Sample energy and set weight
-            Real nu;
+            Real lnu;
             int counter = 0;
             Real prob;
             do {
-              nu = exp(rng_gen.drand() * (lnu_max - lnu_min) + lnu_min);
+              lnu = rng_gen.drand() * (lnu_max - lnu_min) + lnu_min;
               counter++;
               PARTHENON_REQUIRE(counter < 100000,
                                 "Inefficient or impossible frequency sampling!");
-              Real lnu = log(nu);
               Real dn = (lnu - lnu_min) / dlnu;
               int n = static_cast<int>(dn);
               dn = dn - n;
               prob = (1. - dn) * dNdlnu(n, sidx, k, j, i) +
                      dn * dNdlnu(n + 1, sidx, k, j, i);
             } while (rng_gen.drand() > prob);
+            Real nu = exp(lnu);
 
             weight(m) = GetWeight(wgtC / wgtCfac, nu);
 

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -290,9 +290,9 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
               Real dn = (lnu - lnu_min) / dlnu;
               int n = static_cast<int>(dn);
               dn = dn - n;
-              prob = (1. - dn) * dNdlnu(n, sidx, k, j, i) + dn * dNdlnu(n + 1, sidx, k, j, i);
+              prob = (1. - dn) * dNdlnu(n, sidx, k, j, i) +
+                     dn * dNdlnu(n + 1, sidx, k, j, i);
             } while (rng_gen.drand() > prob);
-
 
             weight(m) = GetWeight(wgtC / wgtCfac, nu);
 

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -64,8 +64,9 @@ constexpr RadiationType species[MaxNumRadiationSpecies] = {
     RadiationType::NU_ELECTRON, RadiationType::NU_ELECTRON_ANTI, RadiationType::NU_HEAVY};
 
 KOKKOS_INLINE_FUNCTION
-Real LogLinearInterp(Real x, int sidx, int k, int j, int i, ParArrayND<Real> table,
+Real LogLinearInterp(Real x, int sidx, int k, int j, int i, const ParArrayND<Real> &table,
                      Real lx_min, Real dlx) {
+  PARTHENON_FAIL("This function cannot currently be called on device for some reason!");
   Real lx = log(x);
   Real dn = (lx - lx_min) / dlx;
   int n = static_cast<int>(dn);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

We were calling `LinearInterpLog` inside the `while ()` of a `do {} while ()` loop in the Monte Carlo sampling, and for some reason on device (power9 for me) this generates a segfault when the `dNdlnu` `ParArrayND<Real>` is passed to that inline function, either as a copy or a const reference. Don't know why that is, but the simple fix is to write out the interpolation routine in the actual `par_for`. 

This runs the `thincooling.pin` problem to completion though I didn't check the output for accuracy.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
