### PR TITLE
Add LeptonSign functionality

### DIFF
--- a/src/pgen/thin_cooling.cpp
+++ b/src/pgen/thin_cooling.cpp
@@ -63,7 +63,8 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   const bool do_nu_e = pin->GetBoolean("radiation", "do_nu_electron");
   const bool do_nu_ebar = pin->GetBoolean("radiation", "do_nu_electron_anti");
-  PARTHENON_REQUIRE(do_nu_e != do_nu_ebar, "Thincooling only supports nu_e or nu_e_bar neutrinos, not both.");
+  PARTHENON_REQUIRE(do_nu_e != do_nu_ebar,
+                    "Thincooling only supports nu_e or nu_e_bar neutrinos, not both.");
 
   // set Ye based on radiation type
   const Real Ye0 = (do_nu_e) ? 0.5 : 0.0;

--- a/src/pgen/thin_cooling.cpp
+++ b/src/pgen/thin_cooling.cpp
@@ -60,6 +60,13 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
   const Real x1max = pin->GetReal("parthenon/mesh", "x1max");
   const std::string rad_method = pin->GetString("radiation", "method");
+
+  const bool do_nu_e = pin->GetBoolean("radiation", "do_nu_electron");
+  const bool do_nu_ebar = pin->GetBoolean("radiation", "do_nu_electron_anti");
+  PARTHENON_REQUIRE(do_nu_e != do_nu_ebar, "Thincooling only supports nu_e or nu_e_bar neutrinos, not both.");
+
+  // set Ye based on radiation type
+  const Real Ye0 = (do_nu_e) ? 0.5 : 0.0;
   /*if (x1max > 1.e-7 && rad_method == "cooling_function") {
     PARTHENON_THROW("Set x1max = 1.e-7 for the cooling_function rad method to get small "
                     "enough timesteps!");
@@ -69,7 +76,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
       "Phoebus::ProblemGenerator::ThinCooling", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         const Real x = coords.Xc<1>(i);
-        Real lambda[2] = {0.5, 0.};
+        Real lambda[2] = {Ye0, 0.};
         if (iye > 0) {
           v(iye, k, j, i) = lambda[0];
         }
@@ -82,7 +89,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         v(igm1, k, j, i) = eos.BulkModulusFromDensityTemperature(
                                v(irho, k, j, i), v(itmp, k, j, i), lambda) /
                            v(iprs, k, j, i);
-        v(iye, k, j, i) = 0.5; // TODO(BRR) change depending on species
+        v(iye, k, j, i) = Ye0;
 
         for (int d = 0; d < 3; d++)
           v(ivlo + d, k, j, i) = 0.0;

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -101,7 +101,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshBlockData<Real> *rc, const doub
             for (int mu = Gcov_lo; mu <= Gcov_lo + 3; mu++) {
               Kokkos::atomic_add(&(v(mu, k, j, i)), -detG * Gcov_coord[mu - Gcov_lo]);
             }
-            Kokkos::atomic_add(&(v(Gye, k, j, i)), -detG * Jye);
+            Kokkos::atomic_add(&(v(Gye, k, j, i)), LeptonSign(s) * detG * Jye);
           });
     }
   }

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -72,6 +72,7 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
   const Real d3x = dx_i * dx_j * dx_k;
 
   auto &phoebus_pkg = pmb->packages.Get("phoebus");
+  auto &unit_conv = phoebus_pkg->Param<phoebus::UnitConversions>("unit_conv");
   auto &code_constants = phoebus_pkg->Param<phoebus::CodeConstants>("code_constants");
 
   const Real h_code = code_constants.h;
@@ -95,7 +96,7 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
   const int Gye = imap[iv::Gye].first;
 
   // TODO(BRR) update this dynamically somewhere else. Get a reasonable starting value
-  Real wgtC = 1.e40; // Typical-ish value
+  Real wgtC = 1.e40 * unit_conv.GetTimeCodeToCGS(); // Typical-ish value
 
   pmb->par_for(
       "MonteCarloZeroFiveForce", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
@@ -436,7 +437,8 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
               Kokkos::atomic_add(&(v(iGcov_lo + 3, k, j, i)),
                                  1. / d4x * weight(n) * k3(n));
               // TODO(BRR) Add Ucon[0] in the below
-              Kokkos::atomic_add(&(v(iGye, k, j, i)), LeptonSign(s) / d4x * weight(n) * mp_code);
+              Kokkos::atomic_add(&(v(iGye, k, j, i)),
+                                 LeptonSign(s) / d4x * weight(n) * mp_code);
 
               absorbed = true;
               Kokkos::atomic_add(&(num_interactions[0]), 1.);

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -96,7 +96,7 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
   const int Gye = imap[iv::Gye].first;
 
   // TODO(BRR) update this dynamically somewhere else. Get a reasonable starting value
-  Real wgtC = 1.e40 * unit_conv.GetTimeCodeToCGS(); // Typical-ish value
+  Real wgtC = 1.e40;// Typical-ish value
 
   pmb->par_for(
       "MonteCarloZeroFiveForce", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -314,8 +314,7 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
               // detG is in both numerator and denominator
               v(mu, k, j, i) -= 1. / (d3x * dt) * weight(m) * K_coord[mu - Gcov_lo];
             }
-            // TODO(BRR) lepton sign
-            v(Gye, k, j, i) -= 1. / (d3x * dt) * Ucon[0] * weight(m) * mp_code;
+            v(Gye, k, j, i) += LeptonSign(s) / (d3x * dt) * Ucon[0] * weight(m) * mp_code;
 
           } // for n
           rng_pool.free_state(rng_gen);
@@ -437,7 +436,7 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
               Kokkos::atomic_add(&(v(iGcov_lo + 3, k, j, i)),
                                  1. / d4x * weight(n) * k3(n));
               // TODO(BRR) Add Ucon[0] in the below
-              Kokkos::atomic_add(&(v(iGye, k, j, i)), 1. / d4x * weight(n) * mp_code);
+              Kokkos::atomic_add(&(v(iGye, k, j, i)), LeptonSign(s) / d4x * weight(n) * mp_code);
 
               absorbed = true;
               Kokkos::atomic_add(&(num_interactions[0]), 1.);

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -96,7 +96,7 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
   const int Gye = imap[iv::Gye].first;
 
   // TODO(BRR) update this dynamically somewhere else. Get a reasonable starting value
-  Real wgtC = 1.e40;// Typical-ish value
+  Real wgtC = 1.e40; // Typical-ish value
 
   pmb->par_for(
       "MonteCarloZeroFiveForce", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -69,7 +69,6 @@ int LeptonSign(const RadiationType s) {
   return (std::abs(static_cast<int>(s)) < 2) * (2 * static_cast<int>(s) - 1);
 }
 
-
 KOKKOS_INLINE_FUNCTION
 Real LogLinearInterp(Real x, int sidx, int k, int j, int i, const ParArrayND<Real> &table,
                      Real lx_min, Real dlx) {

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -63,6 +63,13 @@ constexpr int MaxNumRadiationSpecies = 3;
 constexpr RadiationType species[MaxNumRadiationSpecies] = {
     RadiationType::NU_ELECTRON, RadiationType::NU_ELECTRON_ANTI, RadiationType::NU_HEAVY};
 
+KOKKOS_FORCEINLINE_FUNCTION
+int LeptonSign(const RadiationType s) {
+  /* 0 is abs(s) >= 2, otherwise 2s-1 = -1,1 */
+  return (std::abs(static_cast<int>(s)) < 2) * (2 * static_cast<int>(s) - 1);
+}
+
+
 KOKKOS_INLINE_FUNCTION
 Real LogLinearInterp(Real x, int sidx, int k, int j, int i, const ParArrayND<Real> &table,
                      Real lx_min, Real dlx) {


### PR DESCRIPTION
This PR adds a function `LeptonSign` to `radiation.hpp` to return the lepton number based on radiation type. This has been incorporated into `monte_carlo` and `cooling_function` for the `Gye` updates.

`wgtC` is scaled by the time unit so that it can be compared to values computed in nubhlight (this was needed for the `leptoneq` problem). It's a temporary fix until it can be dynamically computed. 

I also modified the thin cooling setup to set the electron fraction based on the radiation type.

![image](https://user-images.githubusercontent.com/39746406/230154855-38d23d0d-289c-430d-88b0-64678677692c.png)
Output from the `leptoneq` problem (color axis is 100(ye - 0.225)).
