### PR TITLE
Fixes to monte carlo transport

### DIFF
--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -210,7 +210,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshBlockData<Real> *rc, const doub
             for (int mu = Gcov_lo; mu <= Gcov_lo + 3; mu++) {
               Kokkos::atomic_add(&(v(mu, k, j, i)), -detG * Gcov_coord[mu - Gcov_lo]);
             }
-            Kokkos::atomic_add(&(v(Gye, k, j, i)), - LeptonSign(s) * detG * Jye);
+            Kokkos::atomic_add(&(v(Gye, k, j, i)), -LeptonSign(s) * detG * Jye);
           });
     }
   }

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -210,7 +210,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshBlockData<Real> *rc, const doub
             for (int mu = Gcov_lo; mu <= Gcov_lo + 3; mu++) {
               Kokkos::atomic_add(&(v(mu, k, j, i)), -detG * Gcov_coord[mu - Gcov_lo]);
             }
-            Kokkos::atomic_add(&(v(Gye, k, j, i)), LeptonSign(s) * detG * Jye);
+            Kokkos::atomic_add(&(v(Gye, k, j, i)), - LeptonSign(s) * detG * Jye);
           });
     }
   }

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -315,7 +315,7 @@ TaskStatus MonteCarloSourceParticles(MeshBlock *pmb, MeshBlockData<Real> *rc,
               // detG is in both numerator and denominator
               v(mu, k, j, i) -= 1. / (d3x * dt) * weight(m) * K_coord[mu - Gcov_lo];
             }
-            v(Gye, k, j, i) += LeptonSign(s) / (d3x * dt) * Ucon[0] * weight(m) * mp_code;
+            v(Gye, k, j, i) -= LeptonSign(s) / (d3x * dt) * Ucon[0] * weight(m) * mp_code;
 
           } // for n
           rng_pool.free_state(rng_gen);

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -415,9 +415,8 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
           int k, j, i;
           swarm_d.Xtoijk(x(n), y(n), z(n), i, j, k);
 
-          Real alphanu = 4. * M_PI *
-                         opacities.AbsorptionCoefficient(
-                             v(prho, k, j, i), v(itemp, k, j, i), v(iye, k, j, i), s, nu);
+          Real alphanu = opacities.AbsorptionCoefficient(
+              v(prho, k, j, i), v(itemp, k, j, i), v(iye, k, j, i), s, nu);
 
           Real dtau_abs = alphanu * dt; // c = 1 in code units
 

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -66,7 +66,7 @@ constexpr RadiationType species[MaxNumRadiationSpecies] = {
 KOKKOS_FORCEINLINE_FUNCTION
 int LeptonSign(const RadiationType s) {
   /* 0 is abs(s) >= 2, otherwise 2s-1 = -1,1 */
-  return (std::abs(static_cast<int>(s)) < 2) * (2 * static_cast<int>(s) - 1);
+  return (std::abs(static_cast<int>(s)) < 2) * (- 2 * static_cast<int>(s) + 1);
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -66,7 +66,7 @@ constexpr RadiationType species[MaxNumRadiationSpecies] = {
 KOKKOS_FORCEINLINE_FUNCTION
 int LeptonSign(const RadiationType s) {
   /* 0 is abs(s) >= 2, otherwise 2s-1 = -1,1 */
-  return (std::abs(static_cast<int>(s)) < 2) * (- 2 * static_cast<int>(s) + 1);
+  return (std::abs(static_cast<int>(s)) < 2) * (-2 * static_cast<int>(s) + 1);
 }
 
 KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
This PR provides two fixes to transport. 
First, #162 adding lepton sign functionality had the lepton number for electrons and their antis backwards.. That is fixed. There are accompanying fixes in the emission updates in `monte_carlo` and `cooling_function`.

Secondly, there was an erroneous 4pi in the `alphanu` term for absorption. That has been removed. Below I show the fornax cooling (first) and thermalization (second) comparisons done with this PR. 

![image](https://user-images.githubusercontent.com/39746406/231527833-e308ae5f-df11-4a1b-9722-940224882bc3.png)
![image](https://user-images.githubusercontent.com/39746406/231527854-effa69c3-eecd-4847-9b95-0c06893a8911.png)
