### PR TITLE
Boundary & misc fixes for MC

### DIFF
--- a/src/phoebus_boundaries/phoebus_boundaries.cpp
+++ b/src/phoebus_boundaries/phoebus_boundaries.cpp
@@ -416,7 +416,7 @@ TaskStatus ConvertBoundaryConditions(std::shared_ptr<MeshBlockData<Real>> &rc) {
     }
   }
 
-  if (pkg_rad->Param<bool>("active")) {
+  if (pkg_rad->Param<bool>("active") && pkg_rad->Param<bool>("moments_active")) {
     // Fluid and rad always have same value
     // std::string bc_vars = pkg_rad->Param<std::string>("bc_vars");
     if (bc_vars == "primitive") {
@@ -508,6 +508,29 @@ void ProcessBoundaryConditions(parthenon::ParthenonManager &pman) {
               pman.app_input
                   ->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x1] =
                   Boundaries::SetSwarmOX1Outflow;
+            }
+          }
+        }
+        if (d == 2) {
+          if (outer == 0) {
+            if (rad_method == "mocmc") {
+              pman.app_input
+                  ->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x2] =
+                  Boundaries::SetSwarmNoWorkBC;
+            } else {
+              pman.app_input
+                  ->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x2] =
+                  Boundaries::SetSwarmIX2Outflow;
+            }
+          } else if (outer == 1) {
+            if (rad_method == "mocmc") {
+              pman.app_input
+                  ->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x2] =
+                  Boundaries::SetSwarmNoWorkBC;
+            } else {
+              pman.app_input
+                  ->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x2] =
+                  Boundaries::SetSwarmOX2Outflow;
             }
           }
         }

--- a/src/phoebus_boundaries/phoebus_boundaries.hpp
+++ b/src/phoebus_boundaries/phoebus_boundaries.hpp
@@ -59,6 +59,12 @@ inline auto SetSwarmIX1Outflow() {
 inline auto SetSwarmOX1Outflow() {
   return parthenon::DeviceAllocate<parthenon::ParticleBoundOX1Outflow>();
 }
+inline auto SetSwarmIX2Outflow() {
+  return parthenon::DeviceAllocate<parthenon::ParticleBoundIX2Outflow>();
+}
+inline auto SetSwarmOX2Outflow() {
+  return parthenon::DeviceAllocate<parthenon::ParticleBoundOX2Outflow>();
+}
 inline auto SetSwarmNoWorkBC() {
   return parthenon::DeviceAllocate<ParticleBoundNoWork>();
 }

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -419,9 +419,10 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
               v(prho, k, j, i), v(itemp, k, j, i), v(iye, k, j, i), s, nu);
 
           Real dtau_abs = alphanu * dt; // c = 1 in code units
-          Real Ucon[4];
           Real vel[3] = {v(ivlo, k, j, i), v(ivlo + 1, k, j, i), v(ivlo + 2, k, j, i)};
-          GetFourVelocity(vel, geom, CellLocation::Cent, k, j, i, Ucon);
+          Real W = GetLorentzFactor(v, geom, CellLocation::Cent, k, j, i);
+          Real alpha = geom.Lapse(CellLocation::Cent, k, j, i);
+          Real Ucon0 = robust::ratio(W, std::abs(alpha));
 
           bool absorbed = false;
 

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -440,7 +440,7 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
               Kokkos::atomic_add(&(v(iGcov_lo + 3, k, j, i)),
                                  1. / d4x * weight(n) * k3(n));
               Kokkos::atomic_add(&(v(iGye, k, j, i)),
-                                 LeptonSign(s) / d4x * weight(n) * mp_code * Ucon[0]);
+                                 LeptonSign(s) / d4x * weight(n) * mp_code * Ucon0);
 
               absorbed = true;
               Kokkos::atomic_add(&(num_interactions[0]), 1.);

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -419,6 +419,9 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
               v(prho, k, j, i), v(itemp, k, j, i), v(iye, k, j, i), s, nu);
 
           Real dtau_abs = alphanu * dt; // c = 1 in code units
+          Real Ucon[4];
+          Real vel[3] = {v(pvlo, k, j, i), v(pvlo + 1, k, j, i), v(pvlo + 2, k, j, i)};
+          GetFourVelocity(vel, geom, CellLocation::Cent, k, j, i, Ucon);
 
           bool absorbed = false;
 
@@ -435,9 +438,8 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
                                  1. / d4x * weight(n) * k2(n));
               Kokkos::atomic_add(&(v(iGcov_lo + 3, k, j, i)),
                                  1. / d4x * weight(n) * k3(n));
-              // TODO(BRR) Add Ucon[0] in the below
               Kokkos::atomic_add(&(v(iGye, k, j, i)),
-                                 LeptonSign(s) / d4x * weight(n) * mp_code);
+                                 LeptonSign(s) / d4x * weight(n) * mp_code * Ucon[0]);
 
               absorbed = true;
               Kokkos::atomic_add(&(num_interactions[0]), 1.);

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -420,7 +420,7 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
 
           Real dtau_abs = alphanu * dt; // c = 1 in code units
           Real Ucon[4];
-          Real vel[3] = {v(pvlo, k, j, i), v(pvlo + 1, k, j, i), v(pvlo + 2, k, j, i)};
+          Real vel[3] = {v(ivlo, k, j, i), v(ivlo + 1, k, j, i), v(ivlo + 2, k, j, i)};
           GetFourVelocity(vel, geom, CellLocation::Cent, k, j, i, Ucon);
 
           bool absorbed = false;

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -620,10 +620,7 @@ TaskStatus InitializeCommunicationMesh(const std::string swarmName,
     auto &pmb = block;
     auto sc = pmb->swarm_data.Get();
     auto swarm = sc->Get(swarmName);
-    for (int n = 0; n < swarm->vbswarm->bd_var_.nbmax; n++) {
-      auto &nb = pmb->pbval->neighbor[n];
-      swarm->vbswarm->bd_var_.flag[nb.bufid] = BoundaryStatus::waiting;
-    }
+    swarm->ResetCommunication();
   }
 
   return TaskStatus::complete;

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -420,7 +420,7 @@ TaskStatus MonteCarloTransport(MeshBlock *pmb, MeshBlockData<Real> *rc,
 
           Real dtau_abs = alphanu * dt; // c = 1 in code units
           Real vel[3] = {v(ivlo, k, j, i), v(ivlo + 1, k, j, i), v(ivlo + 2, k, j, i)};
-          Real W = GetLorentzFactor(v, geom, CellLocation::Cent, k, j, i);
+          Real W = GetLorentzFactor(vel, geom, CellLocation::Cent, k, j, i);
           Real alpha = geom.Lapse(CellLocation::Cent, k, j, i);
           Real Ucon0 = robust::ratio(W, std::abs(alpha));
 


### PR DESCRIPTION
This PR adds a few fixes / enhancements for monte carlo

- More support for swarm user boundaries, needed for torus's BCs.
- Add the Ucon0 term for monte carlo absorption Ye update
- Bug fix in the monte_carlo boundary bit, add in `swarm->ResetCommunication();` to stop strange crash.
