### PR TITLE
WIP: Number Moments

### DIFF
--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -54,7 +54,7 @@ namespace phoebus {
 PhoebusDriver::PhoebusDriver(ParameterInput *pin, ApplicationInput *app_in, Mesh *pm,
                              const bool is_restart)
     : EvolutionDriver(pin, app_in, pm),
-      integrator(std::make_unique<StagedIntegrator>(pin)), is_restart_(is_restart) {
+      integrator(std::make_unique<parthenon::LowStorageIntegrator>(pin)), is_restart_(is_restart) {
 
   // fail if these are not specified in the input file
   pin->CheckRequired("parthenon/mesh", "ix1_bc");

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -329,9 +329,9 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
       auto moment_flux = moment_flux_E; 
       if (rad_moment_number_evolve) { 
         moment_recon =
-            tl.AddTask(moment_flux_E, radiation::ReconstructEdgeStates<MDT, RadEnergyMoment::Number>, sc0.get());
+            tl.AddTask(moment_flux_E, radiation::ReconstructEdgeStates<MDT, radiation::RadEnergyMoment::Number>, sc0.get());
         moment_flux =
-            tl.AddTask(moment_recon, radiation::CalculateFluxes<MDT, RadEnergyMoment::Number>, sc0.get());
+            tl.AddTask(moment_recon, radiation::CalculateFluxes<MDT, radiation::RadEnergyMoment::Number>, sc0.get());
       }
       auto moment_geom_src = tl.AddTask(none, radiation::CalculateGeometricSource<MDT>,
                                         sc0.get(), gsrc.get());

--- a/src/phoebus_driver.hpp
+++ b/src/phoebus_driver.hpp
@@ -38,7 +38,7 @@ class PhoebusDriver : public EvolutionDriver {
   TaskListStatus Step();
 
  private:
-  std::unique_ptr<StagedIntegrator> integrator;
+  std::unique_ptr<parthenon::LowStorageIntegrator> integrator;
   const bool is_restart_;
   Real dt_init, dt_init_fact;
 

--- a/src/phoebus_utils/variables.hpp
+++ b/src/phoebus_utils/variables.hpp
@@ -72,6 +72,7 @@ constexpr char srcfail[] = "r.i.src_fail";
   constexpr char dJ[] = "r.i.n.dJ";
   constexpr char kappaJ[] = "r.i.n.kappaJ";
   constexpr char kappaH[] = "r.i.n.kappaH";
+  constexpr char kappaH_mean[] = "r.i.n.kappaH_mean";
   constexpr char JBB[] = "r.i.n.JBB";
   constexpr char tilPi[] = "r.i.n.tilPi";
   }

--- a/src/phoebus_utils/variables.hpp
+++ b/src/phoebus_utils/variables.hpp
@@ -36,11 +36,19 @@ constexpr char ye[] = "c.ye";
 namespace radmoment_prim {
 constexpr char J[] = "r.p.J";
 constexpr char H[] = "r.p.H";
+  namespace num {
+  constexpr char J[] = "r.p.n.J";
+  constexpr char H[] = "r.p.n.H";
+  } // namespace num
 } // namespace radmoment_prim
 
 namespace radmoment_cons {
 constexpr char E[] = "r.c.E";
 constexpr char F[] = "r.c.F";
+  namespace num {
+  constexpr char E[] = "r.c.n.E";
+  constexpr char F[] = "r.c.n.F";
+  } // namespace radmoment_cons
 } // namespace radmoment_cons
 
 namespace radmoment_internal {
@@ -58,6 +66,15 @@ constexpr char tilPi[] = "r.i.tilPi";
 constexpr char kappaH_mean[] = "r.i.kappaH_mean";
 constexpr char c2pfail[] = "r.i.c2p_fail";
 constexpr char srcfail[] = "r.i.src_fail";
+  namespace num { 
+  constexpr char xi[] = "r.i.n.xi";
+  constexpr char phi[] = "r.i.n.phi";
+  constexpr char dJ[] = "r.i.n.dJ";
+  constexpr char kappaJ[] = "r.i.n.kappaJ";
+  constexpr char kappaH[] = "r.i.n.kappaH";
+  constexpr char JBB[] = "r.i.n.JBB";
+  constexpr char tilPi[] = "r.i.n.tilPi";
+  }
 } // namespace radmoment_internal
 
 namespace mocmc_internal {

--- a/src/radiation/closure.hpp
+++ b/src/radiation/closure.hpp
@@ -48,8 +48,8 @@ enum class ClosureVerbosity { quiet, v1, v2 };
 template <ClosureEquation EQ = ClosureEquation::energy_conserve,
           ClosureVerbosity VB = ClosureVerbosity::quiet>
 struct ClosureSettings {
-  static const ClosureEquation eqn_type = EQ;
-  static const ClosureVerbosity verbosity = VB;
+  static constexpr ClosureEquation eqn_type = EQ;
+  static constexpr ClosureVerbosity verbosity = VB;
 };
 
 enum class ClosureCon2PrimStrategy {
@@ -66,7 +66,7 @@ template <class SET = ClosureSettings<>>
 class ClosureEdd {
  public:
   using LocalGeometryType = LocalThreeGeometry;
-
+  static constexpr ClosureEquation eqn_type = SET::eqn_type;
   //-------------------------------------------------------------------------------------
   /// Constructor just calculates the inverse 3-metric, covariant three-velocity, and the
   /// Lorentz factor for the given background state.

--- a/src/radiation/moments.cpp
+++ b/src/radiation/moments.cpp
@@ -34,52 +34,6 @@ using fixup::Bounds;
 using Microphysics::Opacities;
 using Microphysics::EOS::EOS;
 
-struct RadiationVariableNames {
-  static RadiationVariableNames GetByMomentType(RadEnergyMoment type) {
-    namespace cr = radmoment_cons;
-    namespace pr = radmoment_prim;
-    namespace ir = radmoment_internal; 
-    if (type == RadEnergyMoment::Number) { 
-      return RadiationVariableNames{cr::num::E, cr::num::F, 
-                                    pr::num::J, pr::num::H, 
-                                    ir::num::xi, ir::num::phi,
-                                    ir::ql, ir::qr,
-                                    ir::ql_v, ir::qr_v, 
-                                    ir::num::dJ, ir::num::kappaJ, ir::num::kappaH, 
-                                    ir::num::JBB, ir::num::tilPi, ir::num::kappaH_mean,
-                                    ir::c2pfail, ir::srcfail};
-    } else /*if (type == RadEnergyMoment::Energy)*/ { 
-      return RadiationVariableNames{cr::E, cr::F, 
-                                    pr::J, pr::H, 
-                                    ir::xi, ir::phi, 
-                                    ir::ql, ir::qr,
-                                    ir::ql_v, ir::qr_v, 
-                                    ir::dJ, ir::kappaJ, ir::kappaH, 
-                                    ir::JBB, ir::tilPi, ir::kappaH_mean,
-                                    ir::c2pfail, ir::srcfail};
-    }
-  }
-  const std::string& E; 
-  const std::string& F; 
-  const std::string& J;
-  const std::string& H; 
-  
-  const std::string& xi; 
-  const std::string& phi; 
-  const std::string& ql; 
-  const std::string& qr; 
-  const std::string& ql_v; 
-  const std::string& qr_v; 
-  const std::string& dJ; 
-  const std::string& kappaJ; 
-  const std::string& kappaH; 
-  const std::string& JBB; 
-  const std::string& tilPi;
-  const std::string& kappaH_mean; 
-  const std::string& c2pfail; 
-  const std::string& srcfail; 
-};
-
 template <class T>
 class ReconstructionIndexer {
  public:

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -129,7 +129,7 @@ TaskStatus MomentCon2Prim(T *rc);
 template <class T>
 TaskStatus MomentPrim2Con(T *rc, IndexDomain domain = IndexDomain::entire);
 
-template <class T>
+template <class T, bool ENERGY = true>
 TaskStatus ReconstructEdgeStates(T *rc);
 
 template <class T>

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -167,6 +167,52 @@ TaskStatus MOCMCFluidSource(T *rc, const Real dt, const bool update_fluid);
 
 TaskStatus MOCMCUpdateParticleCount(Mesh *pmesh, std::vector<Real> *resolution);
 
+struct RadiationVariableNames {
+  static RadiationVariableNames GetByMomentType(RadEnergyMoment type) {
+    namespace cr = radmoment_cons;
+    namespace pr = radmoment_prim;
+    namespace ir = radmoment_internal; 
+    if (type == RadEnergyMoment::Number) { 
+      return RadiationVariableNames{cr::num::E, cr::num::F, 
+                                    pr::num::J, pr::num::H, 
+                                    ir::num::xi, ir::num::phi,
+                                    ir::ql, ir::qr,
+                                    ir::ql_v, ir::qr_v, 
+                                    ir::num::dJ, ir::num::kappaJ, ir::num::kappaH, 
+                                    ir::num::JBB, ir::num::tilPi, ir::num::kappaH_mean,
+                                    ir::c2pfail, ir::srcfail};
+    } else /*if (type == RadEnergyMoment::Energy)*/ { 
+      return RadiationVariableNames{cr::E, cr::F, 
+                                    pr::J, pr::H, 
+                                    ir::xi, ir::phi, 
+                                    ir::ql, ir::qr,
+                                    ir::ql_v, ir::qr_v, 
+                                    ir::dJ, ir::kappaJ, ir::kappaH, 
+                                    ir::JBB, ir::tilPi, ir::kappaH_mean,
+                                    ir::c2pfail, ir::srcfail};
+    }
+  }
+  const std::string& E; 
+  const std::string& F; 
+  const std::string& J;
+  const std::string& H; 
+  
+  const std::string& xi; 
+  const std::string& phi; 
+  const std::string& ql; 
+  const std::string& qr; 
+  const std::string& ql_v; 
+  const std::string& qr_v; 
+  const std::string& dJ; 
+  const std::string& kappaJ; 
+  const std::string& kappaH; 
+  const std::string& JBB; 
+  const std::string& tilPi;
+  const std::string& kappaH_mean; 
+  const std::string& c2pfail; 
+  const std::string& srcfail; 
+};
+
 } // namespace radiation
 
 #endif // RADIATION_HPP_

--- a/src/radiation/radiation.hpp
+++ b/src/radiation/radiation.hpp
@@ -123,16 +123,18 @@ TaskStatus InitializeCommunicationMesh(const std::string swarmName,
 Real EstimateTimestepBlock(MeshBlockData<Real> *rc);
 
 // Moment tasks
+enum class RadEnergyMoment {Number, Energy};
+
 template <class T>
 TaskStatus MomentCon2Prim(T *rc);
 
 template <class T>
 TaskStatus MomentPrim2Con(T *rc, IndexDomain domain = IndexDomain::entire);
 
-template <class T, bool ENERGY = true>
+template <class T, RadEnergyMoment EMOMENT = RadEnergyMoment::Energy>
 TaskStatus ReconstructEdgeStates(T *rc);
 
-template <class T>
+template <class T, RadEnergyMoment EMOMENT = RadEnergyMoment::Energy>
 TaskStatus CalculateFluxes(T *rc);
 
 template <class T>


### PR DESCRIPTION
## PR Summary
This PR implements the radiation number moment evolution equations. Previously, we just evolved the conserved energy and momentum of the radiation field for each species when using the moments. Now, if the parameter `radiation/do_number_evolution` is set, the conserved number density and a corresponding number flux are also evolved for each species. See the Phoebus notes for a description of the equations that are being implemented. 

Things that still need to get done: 

- [ ] Update `FixFluxes` to operate on both number and energy moments (this requires splitting into separate functions for hydro and radiation, at least to minimize code duplication). 
- [ ] Update `ApplyFloors` to operate on both number and energy moments.
- [ ] Add `MomentRedshiftingSource` task, which includes the extra RHS terms the number flux equation picks up due to redshifting. This requires calculating the expansion, acceleration, and shear of the fluid 4-velocity field. The expansion and acceleration are also need to be included in the asymptotic flux expression. 
- [ ] Update opacity function to get equilibrium number density. Does singularity provide this? 
- [ ] Update source functions to allow for multiple species and for evolution of $Y_e$. This is probably the biggest chunk of work. 
- [ ] Run old tests to make sure changes don't break anything. 
- [ ] Set up and run $(T, Y_e)$ and redshifting tests

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
