### PR TITLE
WIP: Add k_mu source terms

### DIFF
--- a/scripts/python/plot_snap2d.py
+++ b/scripts/python/plot_snap2d.py
@@ -70,7 +70,6 @@ def plot_dump(
     coordname = "g.n.coord"
     coord = data.Get(coordname, False)
     z = coord[:, 3, :, nG - 1 : -1 - nG, nG - 1 : -1 - nG]
-    print(np.shape(z))
     y = coord[:, 2, :, nG - 1 : -1 - nG, nG - 1 : -1 - nG]
     x = coord[:, 1, :, nG - 1 : -1 - nG, nG - 1 : -1 - nG]
 
@@ -100,7 +99,7 @@ def plot_dump(
     fig = plt.figure()
     p = fig.add_subplot(111, aspect=1)
     for i in range(NB):
-        val = q[i, 0, :, :]
+        val = 100.0 * (q[i, 0, :, :] - 0.225)
         if len(val.shape) > 2:
             print("WARNING plotting the 0th index of multidimensional variable!")
             val = val[:, :, 0]

--- a/src/radiation/geodesics.hpp
+++ b/src/radiation/geodesics.hpp
@@ -46,7 +46,7 @@ void GetKSource(Real &X0, Real &X1, Real &X2, Real &X3, Real &Kcov0, Real &Kcov1
 
   constexpr Real DELTA = 1.0e-6;
 
-  SPACETIMELOOP(mu) { 
+  SPACETIMELOOP(mu) {
     source[mu] = 0.;
     Xp[0] = X0;
     Xp[1] = X1;
@@ -66,8 +66,7 @@ void GetKSource(Real &X0, Real &X1, Real &X2, Real &X3, Real &Kcov0, Real &Kcov1
     }
 
     source[mu] *= -1.0 / (2.0 * Kcon0);
-
-  }  
+  }
 }
 
 KOKKOS_INLINE_FUNCTION
@@ -108,11 +107,6 @@ void PushParticle(Real &X0, Real &X1, Real &X2, Real &X3, Real &Kcov0, Real &Kco
   X1 += 0.5 * dt * (c1[1] + c2[1]);
   X2 += 0.5 * dt * (c1[2] + c2[2]);
   X3 += 0.5 * dt * (c1[3] + c2[3]);
-  if ( X1 < 0.0 ) {
-    std::printf("X1 < 0 in Push %f %f %f %f\n ", X1, c1[1], c2[1], X1-0.5*dt*(c1[1]+c2[1]));
-    std::printf("X2 in Push %f %f %f %f\n ", X2, c1[2], c2[2], X2-0.5*dt*(c1[2]+c2[2]));
-    std::printf("X3 in Push %f %f %f %f\n ", X3, c1[3], c2[3], X3-0.5*dt*(c1[3]+c2[3]));
-  }
 
   Kcov0 += 0.5 * dt * (d1[0] + d2[0]);
   Kcov1 += 0.5 * dt * (d1[1] + d2[1]);


### PR DESCRIPTION
This PR adds calculations for `k_mu` source terms (`radiation/geodesics.hpp`) for arbitrary metric/geometry as it was previously specialized to Minkowski. This was causing unphysical positions when running the torus problem. It now runs beyond the problem point and a longer run in in the queue. The `leptoneq` problem seems reasonable.

Also removes a print statement from `plot_snap2d` that I left from before.

TODO:
 - [ ] There are redundant calculations (in Minowski all the sources are 0, in FMKS only 2 are non zero) and we are doing more integration than necessary. Performant way to specialize? Template on geometry?
 - [ ] Write a simple test for particles around a Kerr black hole to say for sure that the Push is doing what we want.
