### PR TITLE
Fix GPU compilation for Monte Carlo

### DIFF
--- a/scripts/python/plot_torus_3d.py
+++ b/scripts/python/plot_torus_3d.py
@@ -459,6 +459,9 @@ if __name__ == "__main__":
         "--coords", type=str, default="cartesian", help="Coordinates to plot in"
     )
     parser.add_argument(
+        "--rlim", type=float, default=40., help="Outer radius at which to plot"
+    )
+    parser.add_argument(
         "files", type=str, nargs="+", help="Files to take a snapshot of"
     )
     args = parser.parse_args()
@@ -466,4 +469,4 @@ if __name__ == "__main__":
     matplotlib.use("Agg")
 
     for i, fname in enumerate(args.files):
-        plot_frame(i, fname, args.savefig, coords=args.coords)
+        plot_frame(i, fname, args.savefig, coords=args.coords, rlim=args.rlim)

--- a/src/radiation/monte_carlo.cpp
+++ b/src/radiation/monte_carlo.cpp
@@ -29,7 +29,6 @@ Real GetWeight(const Real wgtC, const Real nu) { return wgtC / nu; }
 /**
  * Integrate Jtot
  **/
-KOKKOS_INLINE_FUNCTION
 void ComputeTotalEmissivity(Mesh *pmesh) {
   auto rad = pmesh->packages.Get("radiation");
   auto opac = pmesh->packages.Get("opacity");
@@ -83,7 +82,6 @@ void ComputeTotalEmissivity(Mesh *pmesh) {
   rad->UpdateParam<Real>("Jtot", reduction::Sum(Jtot));
 }
 
-KOKKOS_INLINE_FUNCTION
 void SetWeight(Mesh *pmesh) {
   auto &phoebus_pkg = pmesh->packages.Get("phoebus");
   auto &unit_conv = phoebus_pkg->Param<phoebus::UnitConversions>("unit_conv");


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

`src/radiation/monte_carlo.cpp` wasn't compiling on Chicoma GPUs; #175 had some `KOKKOS_INLINE_FUNCTION` decorators around host code. This PR removes these, and also adds `rlim` as a runtime parameter to `plot_torus_3d.py`

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
