### PR TITLE
Small history fix for FMKS without MHD

### DIFF
--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   geometry->AddField(geometric_variables::node_coords, gcoord_node);
 
   // Reductions
-  const bool do_mhd = pin->GetBoolean("fluid", "mhd");
+  const bool do_mhd = pin->GetorAddBoolean("fluid", "mhd", false);
   if (params.hasKey("xh") && do_mhd) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -60,8 +60,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   geometry->AddField(geometric_variables::node_coords, gcoord_node);
 
   // Reductions
-  const bool do_hydro = pin->GetBoolean("physics", "hydro");
-  if (params.hasKey("xh") && do_hydro) {
+  const bool do_mhd = pin->GetBoolean("fluid", "mhd");
+  if (params.hasKey("xh") && do_mhd) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;
     using History::ReduceJetMomentumFlux;

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   geometry->AddField(geometric_variables::node_coords, gcoord_node);
 
   // Reductions
-  const bool do_mhd = pin->GetorAddBoolean("fluid", "mhd", false);
+  const bool do_mhd = pin->GetOrAddBoolean("fluid", "mhd", false);
   if (params.hasKey("xh") && do_mhd) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -61,7 +61,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
   // Reductions
   const bool do_mhd = pin->GetOrAddBoolean("fluid", "mhd", false);
-  if (params.hasKey("xh") && do_mhd) {
+  const bool do_hydro = pin->GetBoolean("physics", "hydro");
+  if (params.hasKey("xh") && do_mhd && do_hydro) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;
     using History::ReduceJetMomentumFlux;


### PR DESCRIPTION
When I wrote the history stuff to compute e.g., mass accretion rate and magnetic flux, I checked that we did indeed `do_hydro` .... but not that we are doing MHD. This caused the torus problem without MHD to crash. This should fix that.
