### PR TITLE
fix typo in relative path of Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,8 +170,8 @@ set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON CACHE BOOL "" FORCE)
 # singularity eos
 message(STATUS "Patching mpark::variant to support GPUs")
 execute_process(COMMAND patch -N -s -V never
-  ${CMAKE_CURRENT_SOURCE_DIR}/../external/singularity-eos/utils/variant/include/mpark/variant.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/../external/singularity-eos/utils/cuda_compatibility.patch
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/singularity-eos/utils/variant/include/mpark/variant.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/external/singularity-eos/utils/cuda_compatibility.patch
 )
 
 # message("Configuring singularity-eos")


### PR DESCRIPTION
typo in relative path for Cmake file variant patch