### PR TITLE
Fix & refector: Incorrect v^2 calc in some pgens, and move Reducers out of Driver class.

### DIFF
--- a/inputs/advection.pin
+++ b/inputs/advection.pin
@@ -83,6 +83,8 @@ Cv = 1.0
 
 <physics>
 hydro = true
+rad = false
+tracers = false
 
 <fluid>
 xorder = 2
@@ -93,8 +95,8 @@ c2p_max_iter = 100
 Ye = true
 
 <advection>
-rho = 1
-u = 1
+rho = 1.0
+u = 1.0
 vx = 0.5
 vy = 0.5
 vz = 0.5

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -318,6 +318,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
         HstSum, ReduceMom, "total X" + std::to_string(d + 1) + " momentum"));
   }
 
+  AllReduce<std::vector<Real>> net_field_totals;
+  AllReduce<std::vector<Real>> net_field_totals_2;
+  physics->AddParam<>("net_field_totals", net_field_totals, true);
+  physics->AddParam<>("net_field_totals_2", net_field_totals_2, true);
+
   params.Add(parthenon::hist_param_key, hst_vars);
 
   // Fill Derived and Estimate Timestep

--- a/src/pgen/advection.cpp
+++ b/src/pgen/advection.cpp
@@ -59,7 +59,6 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
 
   auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
-  //auto geom = Geometry::GetCoordinateSystem(rc);
   auto geom = Geometry::GetCoordinateSystem(rc.get());
 
   pmb->par_for(

--- a/src/pgen/kh.cpp
+++ b/src/pgen/kh.cpp
@@ -66,6 +66,8 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   auto emin = pmb->packages.Get("eos")->Param<Real>("sie_min");
   auto emax = pmb->packages.Get("eos")->Param<Real>("sie_max");
 
+  auto geom = Geometry::GetCoordinateSystem(rc.get());
+
   RNGPool rng_pool(pin->GetOrAddInteger("kelvin_helmholtz", "seed", 37));
 
   pmb->par_for(
@@ -77,6 +79,9 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         const Real rho = y < 0.25 ? rho1 : rho0;
         const Real P = y < 0.25 ? P1 : P0;
         const Real vel = y < 0.25 ? v1 : v0;
+
+        Real gcov[4][4];
+        geom.SpacetimeMetric(0.0, x, y, 0.0, gcov);
 
         Real eos_lambda[2];
         if (iye > 0) {
@@ -98,7 +103,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
           v(ivlo + d, k, j, i) = v_pert * 2.0 * (rng_gen.drand() - 0.5);
         v(ivlo, k, j, i) += vel;
         Real vsq = 0.;
-        SPACELOOP2(ii, jj) { vsq += v(ivlo + ii, k, j, i) * v(ivlo + jj, k, j, i); }
+        SPACELOOP2(ii, jj) { vsq += gcov[ii + 1][jj + 1] * v(ivlo + ii, k, j, i) * v(ivlo + jj, k, j, i); }
         const Real W = 1. / sqrt(1. - vsq);
         SPACELOOP(ii) { v(ivlo + ii, k, j, i) *= W; }
         if (ib_hi > 0) {

--- a/src/pgen/kh.cpp
+++ b/src/pgen/kh.cpp
@@ -103,7 +103,9 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
           v(ivlo + d, k, j, i) = v_pert * 2.0 * (rng_gen.drand() - 0.5);
         v(ivlo, k, j, i) += vel;
         Real vsq = 0.;
-        SPACELOOP2(ii, jj) { vsq += gcov[ii + 1][jj + 1] * v(ivlo + ii, k, j, i) * v(ivlo + jj, k, j, i); }
+        SPACELOOP2(ii, jj) {
+          vsq += gcov[ii + 1][jj + 1] * v(ivlo + ii, k, j, i) * v(ivlo + jj, k, j, i);
+        }
         const Real W = 1. / sqrt(1. - vsq);
         SPACELOOP(ii) { v(ivlo + ii, k, j, i) *= W; }
         if (ib_hi > 0) {

--- a/src/pgen/linear_modes.cpp
+++ b/src/pgen/linear_modes.cpp
@@ -247,7 +247,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         }
 
         Real vsq = 0.;
-        SPACELOOP2(ii, jj) { vsq += v(ivlo + ii, k, j, i) * v(ivlo + jj, k, j, i); }
+        SPACELOOP(ii) { vsq += v(ivlo + ii, k, j, i) * v(ivlo + ii, k, j, i); }
         Real Gamma = sqrt(1. + vsq);
 
         if (is_snake || is_inchworm || is_boosted_minkowski) {

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -335,11 +335,17 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
   // Extra per-step user work
   TaskRegion &sync_region_5 = tc.AddRegion(num_partitions);
   int sync_region_5_dep_id;
-  net_field_totals.val.resize(2); // Mdot, Phi
-  net_field_totals_2.val.resize(2);
+
+  // Mdot, Phi
+  AllReduce<std::vector<Real>> *net_field_totals =
+      fluid->MutableParam<AllReduce<std::vector<Real>>>("net_field_totals");
+  AllReduce<std::vector<Real>> *net_field_totals_2 =
+      fluid->MutableParam<AllReduce<std::vector<Real>>>("net_field_totals_2");
+  net_field_totals->val.resize(2); 
+  net_field_totals_2->val.resize(2);
   for (int i = 0; i < 2; i++) {
-    net_field_totals.val[i] = 0.;
-    net_field_totals_2.val[i] = 0.;
+    net_field_totals->val[i] = 0.;
+    net_field_totals_2->val[i] = 0.;
   }
   for (int i = 0; i < num_partitions; i++) {
     sync_region_5_dep_id = 0;
@@ -352,17 +358,17 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
 
     // Evaluate current Mdot, Phi
     auto sum_mdot_1 = tl.AddTask(none, fixup::SumMdotPhiForNetFieldScaling, md.get(), t,
-                                 stage, &(net_field_totals.val));
+                                 stage, &(net_field_totals->val));
 
     sync_region_5.AddRegionalDependencies(sync_region_5_dep_id, i, sum_mdot_1);
     sync_region_5_dep_id++;
 
     TaskID start_reduce_1 = (i == 0 ? tl.AddTask(sum_mdot_1, fixup::NetFieldStartReduce,
-                                                 md.get(), t, stage, &net_field_totals)
+                                                 md.get(), t, stage, net_field_totals)
                                     : none);
     // Test the reduction until it completes
     TaskID finish_reduce_1 = tl.AddTask(start_reduce_1, fixup::NetFieldCheckReduce,
-                                        md.get(), t, stage, &net_field_totals);
+                                        md.get(), t, stage, net_field_totals);
     sync_region_5.AddRegionalDependencies(sync_region_5_dep_id, i, finish_reduce_1);
     sync_region_5_dep_id++;
 
@@ -371,16 +377,16 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
 
     // Evaluate Mdot, Phi (only Phi changes) after modifying B field
     auto sum_mdot_2 = tl.AddTask(mod_net, fixup::SumMdotPhiForNetFieldScaling, md.get(),
-                                 t, stage, &(net_field_totals_2.val));
+                                 t, stage, &(net_field_totals_2->val));
     sync_region_5.AddRegionalDependencies(sync_region_5_dep_id, i, sum_mdot_2);
     sync_region_5_dep_id++;
 
     TaskID start_reduce_2 = (i == 0 ? tl.AddTask(sum_mdot_2, fixup::NetFieldStartReduce,
-                                                 md.get(), t, stage, &net_field_totals_2)
+                                                 md.get(), t, stage, net_field_totals_2)
                                     : none);
     // Test the reduction until it completes
     TaskID finish_reduce_2 = tl.AddTask(start_reduce_2, fixup::NetFieldCheckReduce,
-                                        md.get(), t, stage, &net_field_totals_2);
+                                        md.get(), t, stage, net_field_totals_2);
     sync_region_5.AddRegionalDependencies(sync_region_5_dep_id, i, finish_reduce_2);
     sync_region_5_dep_id++;
 
@@ -390,7 +396,7 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
 
     auto set_scale =
         tl.AddTask(mod_net_2, fixup::UpdateNetFieldScaleControls, md.get(), t, dt, stage,
-                   &(net_field_totals.val), &(net_field_totals_2.val));
+                   &(net_field_totals->val), &(net_field_totals_2->val));
 
     // End tuning region that only evaluates occasionally and on first stage
 
@@ -596,26 +602,28 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
     auto floors = tl.AddTask(radfixup, fixup::ApplyFloors<MeshBlockData<Real>>, sc.get());
 
     if (rad_mocmc_active && stage == integrator->nstages) {
-      particle_resolution.val.resize(1); // total
+      AllReduce<std::vector<Real>> *particle_resolution =
+          rad->MutableParam<AllReduce<std::vector<Real>>>("particle_resolution");
+      particle_resolution->val.resize(1); // total
       // for (int i = 0; i < particle_resolution.val.size(); i++) {
-      particle_resolution.val[i] = 0.;
+      particle_resolution->val[i] = 0.;
       //}
       int reg_dep_id = 0;
       // auto &tl = async_region_3[0];
 
       auto update_count = tl.AddTask(none, radiation::MOCMCUpdateParticleCount, pmesh,
-                                     &particle_resolution.val);
+                                     &particle_resolution->val);
 
       async_region_3.AddRegionalDependencies(reg_dep_id, 0, update_count);
       reg_dep_id++;
 
       auto start_count_reduce =
           tl.AddTask(update_count, &AllReduce<std::vector<Real>>::StartReduce,
-                     &particle_resolution, MPI_SUM);
+                     particle_resolution, MPI_SUM);
 
       auto finish_count_reduce =
           tl.AddTask(start_count_reduce, &AllReduce<std::vector<Real>>::CheckReduce,
-                     &particle_resolution);
+                     particle_resolution);
       async_region_3.AddRegionalDependencies(reg_dep_id, 0, finish_count_reduce);
       reg_dep_id++;
 
@@ -629,7 +637,7 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
                                                    << std::endl;
                                          return TaskStatus::complete;
                                        },
-                                       &particle_resolution.val)
+                                       &particle_resolution->val)
                                  : none);
     }
 
@@ -914,27 +922,30 @@ TaskListStatus PhoebusDriver::MonteCarloStep() {
      **/
     TaskRegion &tuning_region = tc.AddRegion(1);
     {
-      particle_resolution.val.resize(4); // made, absorbed, scattered, total
+      auto rad = pmesh->packages.Get("radiation");
+      AllReduce<std::vector<Real>> *particle_resolution =
+          rad->MutableParam<AllReduce<std::vector<Real>>>("particle_resolution");
+      particle_resolution->val.resize(4); // made, absorbed, scattered, total
       for (int i = 0; i < 4; i++) {
-        particle_resolution.val[i] = 0.;
+        particle_resolution->val[i] = 0.;
       }
       int reg_dep_id = 0;
       auto &tl = tuning_region[0];
 
       auto update_resolution =
           tl.AddTask(none, radiation::MonteCarloUpdateParticleResolution, pmesh,
-                     &particle_resolution.val);
+                     &particle_resolution->val);
 
       tuning_region.AddRegionalDependencies(reg_dep_id, 0, update_resolution);
       reg_dep_id++;
 
       auto start_resolution_reduce =
           tl.AddTask(update_resolution, &AllReduce<std::vector<Real>>::StartReduce,
-                     &particle_resolution, MPI_SUM);
+                     particle_resolution, MPI_SUM);
 
       auto finish_resolution_reduce =
           tl.AddTask(start_resolution_reduce, &AllReduce<std::vector<Real>>::CheckReduce,
-                     &particle_resolution);
+                     particle_resolution);
       tuning_region.AddRegionalDependencies(reg_dep_id, 0, finish_resolution_reduce);
       reg_dep_id++;
 
@@ -949,12 +960,12 @@ TaskListStatus PhoebusDriver::MonteCarloStep() {
                                  << " total = " << (*res)[3] << std::endl;
                        return TaskStatus::complete;
                      },
-                     &particle_resolution.val)
+                     &particle_resolution->val)
                : none);
 
       auto update_tuning =
           tl.AddTask(finish_resolution_reduce, radiation::MonteCarloUpdateTuning, pmesh,
-                     &particle_resolution.val, t0, dt);
+                     &particle_resolution->val, t0, dt);
     }
 
     status = tc.Execute();

--- a/src/phoebus_driver.hpp
+++ b/src/phoebus_driver.hpp
@@ -42,12 +42,6 @@ class PhoebusDriver : public EvolutionDriver {
   const bool is_restart_;
   Real dt_init, dt_init_fact;
 
-  AllReduce<Real> dNtot;
-  AllReduce<std::vector<Real>> particle_resolution;
-  AllReduce<int> particles_outstanding;
-
-  AllReduce<std::vector<Real>> net_field_totals;
-  AllReduce<std::vector<Real>> net_field_totals_2;
 };
 
 parthenon::Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin);

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -319,6 +319,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   }
 
   if (method == "monte_carlo" || method == "mocmc") {
+    // reducers
+    AllReduce<Real> dNtot;
+    AllReduce<std::vector<Real>> particle_resolution;
+    AllReduce<int> particles_outstanding;
+    physics->AddParam<>("particle_resolution", particle_resolution, true);
+    physics->AddParam<>("particles_outstanding", particles_outstanding, true);
+    physics->AddParam<>("dNtot", dNtot, true);
+
     // Initialize random number generator pool
     int rng_seed = pin->GetOrAddInteger("radiation", "rng_seed", 238947);
     physics->AddParam<>("rng_seed", rng_seed);


### PR DESCRIPTION
The name says it all. When I was trying to test tracers with the 2D advection problem, I eventually found that the `vsq` calculation was erroneous, showing the following pattern (psueudocode):

```
SPACELOOP2(ii, jj) { vsq += v(ii) * v(jj); }
```

Namely, it was either 1) missing the metric (which would collapse the sum in Minkowski or 2) should've been manually collapsed to just `SPACELOOP(ii)`. The result was `vsq > 1` and unphysical Lorentz factors. This PR fixes that by pulling in the metric (opting for the more general solution). I noticed the same pattern in the `kh` and `linear_modes` problems. `kh` is fixed the same, while `linear_modes` I replaced the loop with a 1D `SPACELOOP` to not fight with the existing metric for when using e.g., snake coordinates. 

There's a (somewhat) unrelated refactor in this PR. I was working on adding a Parthenon-style advection regression test #187 but ran into an issue: the reducer objects for e.g., `particle_resolution` in the Driver class would have their destructors called after MPI/Kokkos finalize and Phoebus would exit with an error code, which caused the regression testing to exit with an error, too. So, this PR also refactors those Reducer objects as mutable params into `radiation` and `fluid`, where appropriate. I also split off the Driver creation and execution into its own scope. Not necessary with the refactor, but safer and potentially more future-proof. In a separate PR I'll pull in the regression testing (see #187 ).


