### PR TITLE
Fix: No more MeshData parent pointers in torus history callbacks

### DIFF
--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -21,14 +21,10 @@
 
 namespace History {
 
-Real ReduceMassAccretionRate(MeshData<Real> *md) {
+Real ReduceMassAccretionRate(MeshData<Real> *md, const Real xh) {
   const auto ib = md->GetBoundsI(IndexDomain::interior);
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
   const auto kb = md->GetBoundsK(IndexDomain::interior);
-
-  Mesh *pmesh = md->GetMeshPointer();
-  auto &pars = pmesh->packages.Get("geometry")->AllParams();
-  const Real xh = pars.Get<Real>("xh");
 
   namespace p = fluid_prim;
   const std::vector<std::string> vars({p::density::name(), p::velocity::name()});
@@ -70,14 +66,10 @@ Real ReduceMassAccretionRate(MeshData<Real> *md) {
   return result;
 } // mass accretion
 
-Real ReduceJetEnergyFlux(MeshData<Real> *md) {
+Real ReduceJetEnergyFlux(MeshData<Real> *md, const Real xh, const Real sigma_cutoff) {
   const auto ib = md->GetBoundsI(IndexDomain::interior);
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
   const auto kb = md->GetBoundsK(IndexDomain::interior);
-
-  Mesh *pmesh = md->GetMeshPointer();
-  auto &pars = pmesh->packages.Get("geometry")->AllParams();
-  const Real xh = pars.Get<Real>("xh");
 
   namespace p = fluid_prim;
   const std::vector<std::string> vars(
@@ -93,8 +85,6 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
   const int pb_hi = imap[p::bfield::name()].second;
 
   auto geom = Geometry::GetCoordinateSystem(md);
-
-  const Real sigma_cutoff = pmesh->packages.Get("fluid")->Param<Real>("sigma_cutoff");
 
   Real result = 0.0;
   parthenon::par_reduce(
@@ -130,14 +120,10 @@ Real ReduceJetEnergyFlux(MeshData<Real> *md) {
 
 } // JetEnergyFlux
 
-Real ReduceJetMomentumFlux(MeshData<Real> *md) {
+Real ReduceJetMomentumFlux(MeshData<Real> *md, const Real xh, const Real sigma_cutoff) {
   const auto ib = md->GetBoundsI(IndexDomain::interior);
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
   const auto kb = md->GetBoundsK(IndexDomain::interior);
-
-  Mesh *pmesh = md->GetMeshPointer();
-  auto &pars = pmesh->packages.Get("geometry")->AllParams();
-  const Real xh = pars.Get<Real>("xh");
 
   namespace p = fluid_prim;
   const std::vector<std::string> vars(
@@ -153,8 +139,6 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
   const int pb_hi = imap[p::bfield::name()].second;
 
   auto geom = Geometry::GetCoordinateSystem(md);
-
-  const Real sigma_cutoff = pmesh->packages.Get("fluid")->Param<Real>("sigma_cutoff");
 
   Real result = 0.0;
   parthenon::par_reduce(
@@ -190,14 +174,10 @@ Real ReduceJetMomentumFlux(MeshData<Real> *md) {
 
 } // ReduceJetMomentumFlux
 
-Real ReduceMagneticFluxPhi(MeshData<Real> *md) {
+Real ReduceMagneticFluxPhi(MeshData<Real> *md, const Real xh) {
   const auto ib = md->GetBoundsI(IndexDomain::interior);
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
   const auto kb = md->GetBoundsK(IndexDomain::interior);
-
-  Mesh *pmesh = md->GetMeshPointer();
-  auto &pars = pmesh->packages.Get("geometry")->AllParams();
-  const Real xh = pars.Get<Real>("xh");
 
   namespace c = fluid_cons;
   const std::vector<std::string> vars({c::bfield::name()});
@@ -235,7 +215,7 @@ Real ReduceMagneticFluxPhi(MeshData<Real> *md) {
       },
       result);
   return 0.5 * result; // 0.5 \int detg B^r dx2 dx3
-} // Phi
+} // ReduceMagneticFluxPhi
 
 // SN analysis
 // ReduceLocalizationFunction is not used currently. However this function returns

--- a/src/analysis/history.hpp
+++ b/src/analysis/history.hpp
@@ -39,10 +39,10 @@ using namespace parthenon::package::prelude;
 
 namespace History {
 
-Real ReduceMassAccretionRate(MeshData<Real> *md);
-Real ReduceJetEnergyFlux(MeshData<Real> *md);
-Real ReduceJetMomentumFlux(MeshData<Real> *md);
-Real ReduceMagneticFluxPhi(MeshData<Real> *md);
+Real ReduceMassAccretionRate(MeshData<Real> *md, const Real xh);
+Real ReduceJetEnergyFlux(MeshData<Real> *md, const Real xh, const Real sigma_cutoff);
+Real ReduceJetMomentumFlux(MeshData<Real> *md, const Real xh, const Real sigma_cutoff);
+Real ReduceMagneticFluxPhi(MeshData<Real> *md, const Real xh);
 void ReduceLocalizationFunction(MeshData<Real> *md);
 
 template <typename Reducer_t>

--- a/src/fixup/fixup_netfield.cpp
+++ b/src/fixup/fixup_netfield.cpp
@@ -40,6 +40,7 @@ TaskStatus SumMdotPhiForNetFieldScaling(MeshData<Real> *md, const Real t, const 
                                         std::vector<Real> *sums) {
   Mesh *pm = md->GetMeshPointer();
   StateDescriptor *fix_pkg = pm->packages.Get("fixup").get();
+  const Real xh = pm->packages.Get("geometry")->Param<Real>("xh");
 
   const bool enable_phi_enforcement = fix_pkg->Param<bool>("enable_phi_enforcement");
 
@@ -50,8 +51,8 @@ TaskStatus SumMdotPhiForNetFieldScaling(MeshData<Real> *md, const Real t, const 
       const Real next_dphi_dt_update_time =
           fix_pkg->Param<Real>("next_dphi_dt_update_time");
       if (t >= next_dphi_dt_update_time && t >= enforced_phi_start_time) {
-        const Real Mdot = History::ReduceMassAccretionRate(md);
-        const Real Phi = History::ReduceMagneticFluxPhi(md);
+        const Real Mdot = History::ReduceMassAccretionRate(md, xh);
+        const Real Phi = History::ReduceMagneticFluxPhi(md, xh);
 
         (*sums)[0] += Mdot;
         (*sums)[1] += Phi;

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -62,9 +62,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // Reductions
   const bool do_mhd = pin->GetOrAddBoolean("fluid", "mhd", false);
   const bool do_hydro = pin->GetBoolean("physics", "hydro");
-  const Real xh = params.Get<Real>("xh");
-  const Real sigma_cutoff = pin->GetOrAddReal("fluid", "sigma_cutoff", 1.0);
   if (params.hasKey("xh") && do_mhd && do_hydro) {
+    const Real xh = params.Get<Real>("xh");
+    const Real sigma_cutoff = pin->GetOrAddReal("fluid", "sigma_cutoff", 1.0);
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;
     using History::ReduceJetMomentumFlux;

--- a/src/geometry/geometry.cpp
+++ b/src/geometry/geometry.cpp
@@ -62,6 +62,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // Reductions
   const bool do_mhd = pin->GetOrAddBoolean("fluid", "mhd", false);
   const bool do_hydro = pin->GetBoolean("physics", "hydro");
+  const Real xh = params.Get<Real>("xh");
+  const Real sigma_cutoff = pin->GetOrAddReal("fluid", "sigma_cutoff", 1.0);
   if (params.hasKey("xh") && do_mhd && do_hydro) {
     auto HstSum = parthenon::UserHistoryOperation::sum;
     using History::ReduceJetEnergyFlux;
@@ -71,20 +73,20 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     using parthenon::HistoryOutputVar;
     parthenon::HstVar_list hst_vars = {};
 
-    auto ReduceAccretionRate = [](MeshData<Real> *md) {
-      return ReduceMassAccretionRate(md);
+    auto ReduceAccretionRate = [xh](MeshData<Real> *md) {
+      return ReduceMassAccretionRate(md, xh);
     };
 
-    auto ComputeJetEnergyFlux = [](MeshData<Real> *md) {
-      return ReduceJetEnergyFlux(md);
+    auto ComputeJetEnergyFlux = [xh, sigma_cutoff](MeshData<Real> *md) {
+      return ReduceJetEnergyFlux(md, xh, sigma_cutoff);
     };
 
-    auto ComputeJetMomentumFlux = [](MeshData<Real> *md) {
-      return ReduceJetMomentumFlux(md);
+    auto ComputeJetMomentumFlux = [xh, sigma_cutoff](MeshData<Real> *md) {
+      return ReduceJetMomentumFlux(md, xh, sigma_cutoff);
     };
 
-    auto ComputeMagneticFluxPhi = [](MeshData<Real> *md) {
-      return ReduceMagneticFluxPhi(md);
+    auto ComputeMagneticFluxPhi = [xh](MeshData<Real> *md) {
+      return ReduceMagneticFluxPhi(md, xh);
     };
 
     hst_vars.emplace_back(HistoryOutputVar(HstSum, ReduceAccretionRate, "mdot"));


### PR DESCRIPTION
As pointed out in #208, there was improper use of `MeshData` pointers in the torus history callback functions. This was there in order to grab a couple of params, namely the event horizon `xh` and cutoff magnetization value `sigma_cutoff`. I've removed `MeshData` parent pointers and instead pass the relevant pieces into the functions, lambda captured into the callbacks.
