### PR TITLE
Add eos information to floors, misc UserWorkBeforeOutput fix

### DIFF
--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -349,10 +349,13 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
   auto eos = eos_pkg->Param<EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
-  Bounds *bounds = fix_pkg->MutableParam<Bounds>("bounds");
+  Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
 
   // BLB: Setting EOS bnds for Ceilings/Floors here.
-  bounds->SetEOSBnds(eos_pkg);
+  pbounds->SetEOSBnds(eos_pkg);
+
+  // copy bounds by value for kernel
+  Bounds bounds = *pbounds;
 
   const Real c2p_tol = fluid_pkg->Param<Real>("c2p_tol");
   const int c2p_max_iter = fluid_pkg->Param<int>("c2p_max_iter");
@@ -375,21 +378,21 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
         eos_lambda[1] = std::log10(v(b, tmp, k, j, i)); // use last temp as initial guess
 
         double rho_floor, sie_floor;
-        bounds->GetFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                          coords.Xc<3>(k, j, i), rho_floor, sie_floor);
+        bounds.GetFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                         coords.Xc<3>(k, j, i), rho_floor, sie_floor);
         double gamma_max, e_max;
-        bounds->GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                            coords.Xc<3>(k, j, i), gamma_max, e_max);
+        bounds.GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                           coords.Xc<3>(k, j, i), gamma_max, e_max);
         Real bsqorho_max, bsqou_max;
-        bounds->GetMHDCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                               coords.Xc<3>(k, j, i), bsqorho_max, bsqou_max);
+        bounds.GetMHDCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                              coords.Xc<3>(k, j, i), bsqorho_max, bsqou_max);
         Real J_floor;
-        bounds->GetRadiationFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                                   coords.Xc<3>(k, j, i), J_floor);
+        bounds.GetRadiationFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                                  coords.Xc<3>(k, j, i), J_floor);
         Real xi_max;
         Real garbage;
-        bounds->GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                                     coords.Xc<3>(k, j, i), xi_max, garbage);
+        bounds.GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                                    coords.Xc<3>(k, j, i), xi_max, garbage);
 
         Real rho_floor_max = rho_floor;
         Real u_floor_max = rho_floor * sie_floor;

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -49,6 +49,7 @@ namespace fixup {
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto fix = std::make_shared<StateDescriptor>("fixup");
   Params &params = fix->AllParams();
+  auto mutable_param = parthenon::Params::Mutability::Mutable;
 
   const bool enable_mhd = pin->GetOrAddBoolean("fluid", "mhd", false);
   const bool enable_rad = pin->GetOrAddBoolean("physics", "rad", false);
@@ -273,7 +274,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
              Bounds(params.Get<Floors>("floor"), params.Get<Ceilings>("ceiling"),
                     params.Get<MHDCeilings>("mhd_ceiling"),
                     params.Get<RadiationFloors>("rad_floor"),
-                    params.Get<RadiationCeilings>("rad_ceiling")));
+                    params.Get<RadiationCeilings>("rad_ceiling")),
+             mutable_param);
 
   return fix;
 }
@@ -306,6 +308,9 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   bool enable_rad_floors = fix_pkg->Param<bool>("enable_rad_floors");
 
   if (!enable_floors) return TaskStatus::complete;
+
+  const Real ye_min = eos_pkg->Param<Real>("ye_min");
+  const Real ye_max = eos_pkg->Param<Real>("ye_max");
 
   const std::vector<std::string> vars(
       {p::density::name(), c::density::name(), p::velocity::name(), c::momentum::name(),
@@ -344,7 +349,10 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
   auto eos = eos_pkg->Param<EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
-  auto bounds = fix_pkg->Param<Bounds>("bounds");
+  Bounds *bounds = fix_pkg->MutableParam<Bounds>("bounds");
+
+  // BLB: Setting EOS bnds for Ceilings/Floors here.
+  bounds->SetEOSBnds(eos_pkg);
 
   const Real c2p_tol = fluid_pkg->Param<Real>("c2p_tol");
   const int c2p_max_iter = fluid_pkg->Param<int>("c2p_max_iter");
@@ -367,21 +375,21 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
         eos_lambda[1] = std::log10(v(b, tmp, k, j, i)); // use last temp as initial guess
 
         double rho_floor, sie_floor;
-        bounds.GetFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                         coords.Xc<3>(k, j, i), rho_floor, sie_floor);
+        bounds->GetFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                          coords.Xc<3>(k, j, i), rho_floor, sie_floor);
         double gamma_max, e_max;
-        bounds.GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                           coords.Xc<3>(k, j, i), gamma_max, e_max);
+        bounds->GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                            coords.Xc<3>(k, j, i), gamma_max, e_max);
         Real bsqorho_max, bsqou_max;
-        bounds.GetMHDCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                              coords.Xc<3>(k, j, i), bsqorho_max, bsqou_max);
+        bounds->GetMHDCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                               coords.Xc<3>(k, j, i), bsqorho_max, bsqou_max);
         Real J_floor;
-        bounds.GetRadiationFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                                  coords.Xc<3>(k, j, i), J_floor);
+        bounds->GetRadiationFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                                   coords.Xc<3>(k, j, i), J_floor);
         Real xi_max;
         Real garbage;
-        bounds.GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                                    coords.Xc<3>(k, j, i), xi_max, garbage);
+        bounds->GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                                     coords.Xc<3>(k, j, i), xi_max, garbage);
 
         Real rho_floor_max = rho_floor;
         Real u_floor_max = rho_floor * sie_floor;
@@ -437,16 +445,18 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
         if (floor_applied) {
           Real vp_normalobs[3] = {0}; // Inject floors at rest in normal observer frame
-          Real ye_prim_default = 0.5;
-          eos_lambda[0] = ye_prim_default;
+          Real ye = 0.5;
+          if (pye > 0) {
+            ye = v(b, cye, k, j, i);
+          }
+          eos_lambda[0] = ye;
           Real dprs =
               eos.PressureFromDensityInternalEnergy(drho, ratio(du, drho), eos_lambda);
           Real dgm1 = ratio(
               eos.BulkModulusFromDensityInternalEnergy(drho, ratio(du, drho), eos_lambda),
               dprs);
-          prim2con::p2c(drho, vp_normalobs, bp, du, ye_prim_default, dprs, dgm1, gcov,
-                        gammacon, betacon, alpha, sdetgam, dcrho, dS, dBcons, dtau,
-                        dyecons);
+          prim2con::p2c(drho, vp_normalobs, bp, du, ye, dprs, dgm1, gcov, gammacon,
+                        betacon, alpha, sdetgam, dcrho, dS, dBcons, dtau, dyecons);
 
           // Update cons vars (not B field)
           v(b, crho, k, j, i) += dcrho;
@@ -464,7 +474,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
             SPACELOOP(ii) { v(b, pvel_lo + ii, k, j, i) = vp_normalobs[ii]; }
             v(b, peng, k, j, i) = du;
             if (pye > 0) {
-              v(b, pye, k, j, i) = ye_prim_default;
+              v(b, pye, k, j, i) = ye_min;
             }
 
             // Update auxiliary primitives
@@ -476,9 +486,9 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
                 eos_lambda);
 
             // Update cons vars (not B field)
-            prim2con::p2c(drho, vp_normalobs, bp, du, ye_prim_default, dprs, dgm1, gcov,
-                          gammacon, betacon, alpha, sdetgam, v(b, crho, k, j, i), dS,
-                          dBcons, v(b, ceng, k, j, i), dyecons);
+            prim2con::p2c(drho, vp_normalobs, bp, du, ye, dprs, dgm1, gcov, gammacon,
+                          betacon, alpha, sdetgam, v(b, crho, k, j, i), dS, dBcons,
+                          v(b, ceng, k, j, i), dyecons);
             SPACELOOP(ii) { v(b, cmom_lo + ii, k, j, i) = dS[ii]; }
             if (pye > 0) {
               v(b, cye, k, j, i) = dyecons;

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -208,9 +208,8 @@ class Ceilings {
   }
 
  private:
-  Real g0_, s0_, sie_max_eos_;
+  Real g0_, s0_;
   const int ceiling_flag_;
-  bool eos_bnds_set_;
 };
 
 static struct ConstantBsqRatCeiling {

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -290,7 +290,7 @@ class Bounds {
         radiation_floors_(RadiationFloors()), radiation_ceilings_(RadiationCeilings()) {}
 
   template <class... Args>
-  KOKKOS_INLINE_FUNCTION void SetEOSBnds(Args &&...args) {
+  void SetEOSBnds(Args &&...args) {
     floors_.SetEOSBnds(std::forward<Args>(args)...);
   }
 

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -196,23 +196,14 @@ class Ceilings {
   KOKKOS_INLINE_FUNCTION
   void GetCeilings(const Real x1, const Real x2, const Real x3, Real &gmax,
                    Real &smax) const {
-    if (!eos_bnds_set_) {
-      PARTHENON_FAIL("EOS bounds not set in ceilings.");
-    }
+
     switch (ceiling_flag_) {
     case 1:
       gmax = g0_;
-      smax = std::min(s0_, sie_max_eos_);
+      smax = s0_;
       break;
     default:
       PARTHENON_FAIL("No valid ceiling set.");
-    }
-  }
-
-  void SetEOSBnds(StateDescriptor *eos_pkg) {
-    if (!eos_bnds_set_) {
-      sie_max_eos_ = eos_pkg->Param<Real>("sie_max");
-      eos_bnds_set_ = true;
     }
   }
 
@@ -301,7 +292,6 @@ class Bounds {
   template <class... Args>
   KOKKOS_INLINE_FUNCTION void SetEOSBnds(Args &&...args) {
     floors_.SetEOSBnds(std::forward<Args>(args)...);
-    ceilings_.SetEOSBnds(std::forward<Args>(args)...);
   }
 
   template <class... Args>

--- a/src/fixup/fixup_c2p.cpp
+++ b/src/fixup/fixup_c2p.cpp
@@ -155,7 +155,8 @@ TaskStatus ConservedToPrimitiveFixupImpl(T *rc) {
 
   auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
-  Bounds *bounds = fix_pkg->MutableParam<Bounds>("bounds");
+  Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
+  Bounds bounds = *pbounds;
 
   Coordinates_t coords = rc->GetParentPointer()->coords;
 
@@ -176,8 +177,8 @@ TaskStatus ConservedToPrimitiveFixupImpl(T *rc) {
         eos_lambda[1] = std::log10(v(b, tmp, k, j, i));
 
         Real gamma_max, e_max;
-        bounds->GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                            coords.Xc<3>(k, j, i), gamma_max, e_max);
+        bounds.GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                           coords.Xc<3>(k, j, i), gamma_max, e_max);
 
         if (c2p_failure_force_fixup_both && rad_active) {
           if (v(b, ifail, k, j, i) == con2prim_robust::FailFlags::fail ||

--- a/src/fixup/fixup_c2p.cpp
+++ b/src/fixup/fixup_c2p.cpp
@@ -155,7 +155,7 @@ TaskStatus ConservedToPrimitiveFixupImpl(T *rc) {
 
   auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
-  auto bounds = fix_pkg->Param<Bounds>("bounds");
+  Bounds *bounds = fix_pkg->MutableParam<Bounds>("bounds");
 
   Coordinates_t coords = rc->GetParentPointer()->coords;
 
@@ -176,8 +176,8 @@ TaskStatus ConservedToPrimitiveFixupImpl(T *rc) {
         eos_lambda[1] = std::log10(v(b, tmp, k, j, i));
 
         Real gamma_max, e_max;
-        bounds.GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                           coords.Xc<3>(k, j, i), gamma_max, e_max);
+        bounds->GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                            coords.Xc<3>(k, j, i), gamma_max, e_max);
 
         if (c2p_failure_force_fixup_both && rad_active) {
           if (v(b, ifail, k, j, i) == con2prim_robust::FailFlags::fail ||

--- a/src/fixup/fixup_radc2p.cpp
+++ b/src/fixup/fixup_radc2p.cpp
@@ -113,7 +113,7 @@ TaskStatus RadConservedToPrimitiveFixupImpl(T *rc) {
   }
 
   auto geom = Geometry::GetCoordinateSystem(rc);
-  auto bounds = fix_pkg->Param<Bounds>("bounds");
+  Bounds *bounds = fix_pkg->MutableParam<Bounds>("bounds");
 
   Coordinates_t coords = rc->GetParentPointer()->coords;
 
@@ -129,8 +129,8 @@ TaskStatus RadConservedToPrimitiveFixupImpl(T *rc) {
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
         Real xi_max;
         Real garbage;
-        bounds.GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                                    coords.Xc<3>(k, j, i), xi_max, garbage);
+        bounds->GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                                     coords.Xc<3>(k, j, i), xi_max, garbage);
 
         // It is assumed that the fluid is already fixed up
         auto fail = [&](const int k, const int j, const int i) {

--- a/src/fixup/fixup_src.cpp
+++ b/src/fixup/fixup_src.cpp
@@ -73,7 +73,7 @@ TaskStatus SourceFixupImpl(T *rc) {
   }
 
   auto eos = eos_pkg->Param<EOS>("d.EOS");
-  auto bounds = fix_pkg->Param<Bounds>("bounds");
+  Bounds *bounds = fix_pkg->MutableParam<Bounds>("bounds");
 
   const std::vector<std::string> vars(
       {p::density::name(), c::density::name(), p::velocity::name(), c::momentum::name(),
@@ -151,12 +151,12 @@ TaskStatus SourceFixupImpl(T *rc) {
       kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
         double gamma_max, e_max;
-        bounds.GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                           coords.Xc<3>(k, j, i), gamma_max, e_max);
+        bounds->GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                            coords.Xc<3>(k, j, i), gamma_max, e_max);
         Real xi_max;
         Real garbage;
-        bounds.GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                                    coords.Xc<3>(k, j, i), xi_max, garbage);
+        bounds->GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+                                     coords.Xc<3>(k, j, i), xi_max, garbage);
 
         double eos_lambda[2]; // used for stellarcollapse eos and other EOS's that require
                               // root finding.

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -48,15 +48,15 @@ class Residual {
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
            const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
-           const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
+           const Microphysics::EOS::EOS &eos, const fixup::Bounds *bnds, const Real x1,
            const Real x2, const Real x3, const Real floor_scale_fac)
       : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), v0sq_(v0sq),
         eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
         floor_scale_fac_(floor_scale_fac) {
     lambda_[0] = Ye;
     Real garbage = 0.0;
-    bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
-    bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
+    bounds_->GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
+    bounds_->GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
 
     rho_floor_ *= floor_scale_fac_;
   }
@@ -100,7 +100,7 @@ class Residual {
   Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
                const Real What) {
     Real rho = rhohat_mu(1.0 / What);
-    bounds_.GetFloors(x1_, x2_, x3_, rho, e_floor_);
+    bounds_->GetFloors(x1_, x2_, x3_, rho, e_floor_);
     e_floor_ *= floor_scale_fac_;
     const Real ehat_trial =
         What * (qbar - mu * rbarsq) + vhatsq * What * What / (1.0 + What);
@@ -164,7 +164,7 @@ class Residual {
  private:
   const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_;
   const Microphysics::EOS::EOS &eos_;
-  const fixup::Bounds &bounds_;
+  const fixup::Bounds *bounds_;
   const Real x1_, x2_, x3_;
   const Real floor_scale_fac_;
   Real lambda_[2];
@@ -224,7 +224,7 @@ struct CellGeom {
 template <typename Data_t, typename T>
 class ConToPrim {
  public:
-  ConToPrim(Data_t *rc, fixup::Bounds bnds, const Real tol, const int max_iterations,
+  ConToPrim(Data_t *rc, fixup::Bounds *bnds, const Real tol, const int max_iterations,
             const Real floor_scale_fac, const bool fail_on_floors,
             const bool fail_on_ceilings)
       : bounds(bnds), var(rc->PackVariables(Vars(), imap)),
@@ -278,7 +278,7 @@ class ConToPrim {
   int NumBlocks() { return var.GetDim(5); }
 
  private:
-  fixup::Bounds bounds;
+  fixup::Bounds *bounds;
   PackIndexMap imap;
   const T var;
   const int prho, crho;
@@ -306,11 +306,11 @@ class ConToPrim {
 
     Real rhoflr = 0.0;
     Real epsflr;
-    bounds.GetFloors(x1, x2, x3, rhoflr, epsflr);
+    bounds->GetFloors(x1, x2, x3, rhoflr, epsflr);
     rhoflr *= floor_scale_fac_;
     epsflr *= floor_scale_fac_;
     Real gam_max, eps_max;
-    bounds.GetCeilings(x1, x2, x3, gam_max, eps_max);
+    bounds->GetCeilings(x1, x2, x3, gam_max, eps_max);
 
     const Real D = v(crho) * igdet;
 #if USE_VALENCIA
@@ -456,7 +456,7 @@ class ConToPrim {
 using C2P_Block_t = ConToPrim<MeshBlockData<Real>, VariablePack<Real>>;
 using C2P_Mesh_t = ConToPrim<MeshData<Real>, MeshBlockPack<Real>>;
 
-inline C2P_Block_t ConToPrimSetup(MeshBlockData<Real> *rc, fixup::Bounds bounds,
+inline C2P_Block_t ConToPrimSetup(MeshBlockData<Real> *rc, fixup::Bounds *bounds,
                                   const Real tol, const int max_iter,
                                   const Real c2p_floor_scale_fac,
                                   const bool fail_on_floors,

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -457,7 +457,9 @@ TaskStatus ConservedToPrimitiveRobust(T *rc, const IndexRange &ib, const IndexRa
   auto *pmb = rc->GetParentPointer();
 
   StateDescriptor *fix_pkg = pmb->packages.Get("fixup").get();
+  StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
   fixup::Bounds *bounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
+  bounds->SetEOSBnds(eos_pkg);
 
   StateDescriptor *pkg = pmb->packages.Get("fluid").get();
   const Real c2p_tol = pkg->Param<Real>("c2p_tol");
@@ -469,7 +471,6 @@ TaskStatus ConservedToPrimitiveRobust(T *rc, const IndexRange &ib, const IndexRa
                                                 c2p_floor_scale_fac, c2p_fail_on_floors,
                                                 c2p_fail_on_ceilings);
 
-  StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
   auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   auto coords = pmb->coords;

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -458,8 +458,9 @@ TaskStatus ConservedToPrimitiveRobust(T *rc, const IndexRange &ib, const IndexRa
 
   StateDescriptor *fix_pkg = pmb->packages.Get("fixup").get();
   StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
-  fixup::Bounds *bounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
-  bounds->SetEOSBnds(eos_pkg);
+  fixup::Bounds *pbounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
+  pbounds->SetEOSBnds(eos_pkg);
+  fixup::Bounds bounds = *pbounds;
 
   StateDescriptor *pkg = pmb->packages.Get("fluid").get();
   const Real c2p_tol = pkg->Param<Real>("c2p_tol");

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -13,6 +13,7 @@
 
 #include "fluid.hpp"
 
+#include "analysis/analysis.hpp"
 #include "analysis/history.hpp"
 #include "con2prim.hpp"
 #include "con2prim_robust.hpp"
@@ -207,6 +208,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   physics->AddField(p::entropy::name(), mprim_scalar);
   physics->AddField(p::cs::name(), mprim_scalar);
   physics->AddField(diag::ratio_divv_cs::name(), mprim_scalar);
+  // physics->AddField(diag::localization_function::name(), mprim_scalar);
+  // (MG) currently not in use, turn on when needed.
   physics->AddField(diag::entropy_z_0::name(), mprim_scalar);
   physics->AddField(p::gamma1::name(), mprim_scalar);
   if (ye) {
@@ -309,6 +312,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   // Reductions
   // By default compute integrated value of scalar conserved vars
   auto HstSum = parthenon::UserHistoryOperation::sum;
+  auto HstMax = parthenon::UserHistoryOperation::max;
+  using History::ReduceInGain;
   using History::ReduceOneVar;
   using parthenon::HistoryOutputVar;
   parthenon::HstVar_list hst_vars = {};
@@ -319,6 +324,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto ReduceEn = [](MeshData<Real> *md) {
     return ReduceOneVar<Kokkos::Sum<Real>>(md, fluid_cons::energy::name(), 0);
   };
+  auto MaxDensity = [](MeshData<Real> *md) {
+    return ReduceOneVar<Kokkos::Max<Real>>(md, fluid_prim::density::name(), 0);
+  };
+
+  hst_vars.emplace_back(HistoryOutputVar(HstMax, MaxDensity, "maximum density"));
   hst_vars.emplace_back(HistoryOutputVar(HstSum, ReduceMass, "total baryon number"));
   hst_vars.emplace_back(HistoryOutputVar(HstSum, ReduceEn, "total conserved energy tau"));
 
@@ -441,6 +451,15 @@ TaskStatus ConservedToPrimitiveRegion(T *rc, const IndexRange &ib, const IndexRa
   auto c2p = pkg->Param<c2p_type<T>>("c2p_func");
   return c2p(rc, ib, jb, kb);
 }
+// JMM: Must specialize function for both potential use cases so we
+// can keep it in this file.
+template TaskStatus ConservedToPrimitiveRegion<MeshData<Real>>(MeshData<Real> *rc,
+                                                               const IndexRange &ib,
+                                                               const IndexRange &jb,
+                                                               const IndexRange &kb);
+template TaskStatus ConservedToPrimitiveRegion<MeshBlockData<Real>>(
+    MeshBlockData<Real> *rc, const IndexRange &ib, const IndexRange &jb,
+    const IndexRange &kb);
 
 template <typename T>
 TaskStatus ConservedToPrimitive(T *rc) {
@@ -499,7 +518,7 @@ TaskStatus ConservedToPrimitiveClassic(T *rc, const IndexRange &ib, const IndexR
   auto *pmesh = rc->GetMeshPointer();
 
   StateDescriptor *fix_pkg = pmesh->packages.Get("fixup").get();
-  fixup::Bounds *bounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
+  fixup::Bounds *pbounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
 
   StateDescriptor *pkg = pmesh->packages.Get("fluid").get();
   const Real c2p_tol = pkg->Param<Real>("c2p_tol");

--- a/src/fluid/fluid.hpp
+++ b/src/fluid/fluid.hpp
@@ -29,9 +29,19 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 TaskStatus PrimitiveToConserved(MeshBlockData<Real> *rc);
 TaskStatus PrimitiveToConservedRegion(MeshBlockData<Real> *rc, const IndexRange &ib,
                                       const IndexRange &jb, const IndexRange &kb);
+// JMM: Not sure how the templated value here worked in the first
+// place. But proper solution is need to tell the linker it's
+// available elsewhere.
 template <typename T>
 TaskStatus ConservedToPrimitiveRegion(T *rc, const IndexRange &ib, const IndexRange &jb,
                                       const IndexRange &kb);
+extern template TaskStatus
+ConservedToPrimitiveRegion<MeshData<Real>>(MeshData<Real> *rc, const IndexRange &ib,
+                                           const IndexRange &jb, const IndexRange &kb);
+extern template TaskStatus ConservedToPrimitiveRegion<MeshBlockData<Real>>(
+    MeshBlockData<Real> *rc, const IndexRange &ib, const IndexRange &jb,
+    const IndexRange &kb);
+
 template <typename T>
 TaskStatus ConservedToPrimitive(T *rc);
 template <typename T>

--- a/src/fluid/fluid.hpp
+++ b/src/fluid/fluid.hpp
@@ -29,19 +29,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 TaskStatus PrimitiveToConserved(MeshBlockData<Real> *rc);
 TaskStatus PrimitiveToConservedRegion(MeshBlockData<Real> *rc, const IndexRange &ib,
                                       const IndexRange &jb, const IndexRange &kb);
-// JMM: Not sure how the templated value here worked in the first
-// place. But proper solution is need to tell the linker it's
-// available elsewhere.
 template <typename T>
 TaskStatus ConservedToPrimitiveRegion(T *rc, const IndexRange &ib, const IndexRange &jb,
                                       const IndexRange &kb);
-extern template TaskStatus
-ConservedToPrimitiveRegion<MeshData<Real>>(MeshData<Real> *rc, const IndexRange &ib,
-                                           const IndexRange &jb, const IndexRange &kb);
-extern template TaskStatus ConservedToPrimitiveRegion<MeshBlockData<Real>>(
-    MeshBlockData<Real> *rc, const IndexRange &ib, const IndexRange &jb,
-    const IndexRange &kb);
-
 template <typename T>
 TaskStatus ConservedToPrimitive(T *rc);
 template <typename T>

--- a/src/fluid/riemann.hpp
+++ b/src/fluid/riemann.hpp
@@ -205,7 +205,8 @@ class FluxState {
   const ParArrayND<Real> qr;
   const Geometry::CoordSysMeshBlock geom;
   const Coordinates_t coords;
-  fixup::Bounds *bounds;
+  fixup::Bounds *pbounds;
+  fixup::Bounds bounds;
 
  private:
   const int prho, pvel_lo, peng, pb_lo, pb_hi, pye, prs, gm1;
@@ -216,11 +217,11 @@ class FluxState {
         ql(rc->Get("ql").data), qr(rc->Get("qr").data),
         geom(Geometry::GetCoordinateSystem(rc)),
         coords(rc->GetParentPointer()->coords), // problem for packs
-        bounds(rc->GetParentPointer()
-                   ->packages.Get("fixup")
-                   .get()
-                   ->MutableParam<fixup::Bounds>("bounds")),
-        prho(imap[fluid_prim::density::name()].first),
+        pbounds(rc->GetParentPointer()
+                    ->packages.Get("fixup")
+                    .get()
+                    ->MutableParam<fixup::Bounds>("bounds")),
+        bounds(*pbounds), prho(imap[fluid_prim::density::name()].first),
         pvel_lo(imap[fluid_prim::velocity::name()].first),
         peng(imap[fluid_prim::energy::name()].first),
         pb_lo(imap[fluid_prim::bfield::name()].first),

--- a/src/fluid/riemann.hpp
+++ b/src/fluid/riemann.hpp
@@ -83,7 +83,7 @@ class FluxState {
     const int dir = d - 1;
     Real rho_floor = q(dir, prho, k, j, i);
     Real sie_floor;
-    bounds.GetFloors(g.X[1], g.X[2], g.X[3], rho_floor, sie_floor);
+    bounds->GetFloors(g.X[1], g.X[2], g.X[3], rho_floor, sie_floor);
     const Real rho = std::max(q(dir, prho, k, j, i), rho_floor);
     Real vpcon[] = {q(dir, pvel_lo, k, j, i), q(dir, pvel_lo + 1, k, j, i),
                     q(dir, pvel_lo + 2, k, j, i)};
@@ -205,7 +205,7 @@ class FluxState {
   const ParArrayND<Real> qr;
   const Geometry::CoordSysMeshBlock geom;
   const Coordinates_t coords;
-  fixup::Bounds bounds;
+  fixup::Bounds *bounds;
 
  private:
   const int prho, pvel_lo, peng, pb_lo, pb_hi, pye, prs, gm1;
@@ -216,8 +216,10 @@ class FluxState {
         ql(rc->Get("ql").data), qr(rc->Get("qr").data),
         geom(Geometry::GetCoordinateSystem(rc)),
         coords(rc->GetParentPointer()->coords), // problem for packs
-        bounds(rc->GetParentPointer()->packages.Get("fixup").get()->Param<fixup::Bounds>(
-            "bounds")),
+        bounds(rc->GetParentPointer()
+                   ->packages.Get("fixup")
+                   .get()
+                   ->MutableParam<fixup::Bounds>("bounds")),
         prho(imap[fluid_prim::density::name()].first),
         pvel_lo(imap[fluid_prim::velocity::name()].first),
         peng(imap[fluid_prim::energy::name()].first),
@@ -251,7 +253,7 @@ Real llf(const FluxState &fs, const int d, const int k, const int j, const int i
   CellLocation loc = DirectionToFaceID(d);
   FaceGeom g(fs.coords, fs.geom, loc, d, k, j, i);
   Real gam_max, sie_max;
-  fs.bounds.GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
+  fs.bounds->GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
   fs.prim_to_flux(d, k, j, i, g, fs.ql, vml, vpl, Ul, Fl, sie_max, gam_max);
   fs.prim_to_flux(d, k, j, i, g, fs.qr, vmr, vpr, Ur, Fr, sie_max, gam_max);
 
@@ -273,7 +275,7 @@ Real hll(const FluxState &fs, const int d, const int k, const int j, const int i
   CellLocation loc = DirectionToFaceID(d);
   FaceGeom g(fs.coords, fs.geom, loc, d, k, j, i);
   Real gam_max, sie_max;
-  fs.bounds.GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
+  fs.bounds->GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
   fs.prim_to_flux(d, k, j, i, g, fs.ql, vml, vpl, Ul, Fl, sie_max, gam_max);
   fs.prim_to_flux(d, k, j, i, g, fs.qr, vmr, vpr, Ur, Fr, sie_max, gam_max);
 

--- a/src/fluid/riemann.hpp
+++ b/src/fluid/riemann.hpp
@@ -83,7 +83,7 @@ class FluxState {
     const int dir = d - 1;
     Real rho_floor = q(dir, prho, k, j, i);
     Real sie_floor;
-    bounds->GetFloors(g.X[1], g.X[2], g.X[3], rho_floor, sie_floor);
+    bounds.GetFloors(g.X[1], g.X[2], g.X[3], rho_floor, sie_floor);
     const Real rho = std::max(q(dir, prho, k, j, i), rho_floor);
     Real vpcon[] = {q(dir, pvel_lo, k, j, i), q(dir, pvel_lo + 1, k, j, i),
                     q(dir, pvel_lo + 2, k, j, i)};
@@ -253,7 +253,7 @@ Real llf(const FluxState &fs, const int d, const int k, const int j, const int i
   CellLocation loc = DirectionToFaceID(d);
   FaceGeom g(fs.coords, fs.geom, loc, d, k, j, i);
   Real gam_max, sie_max;
-  fs.bounds->GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
+  fs.bounds.GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
   fs.prim_to_flux(d, k, j, i, g, fs.ql, vml, vpl, Ul, Fl, sie_max, gam_max);
   fs.prim_to_flux(d, k, j, i, g, fs.qr, vmr, vpr, Ur, Fr, sie_max, gam_max);
 
@@ -275,7 +275,7 @@ Real hll(const FluxState &fs, const int d, const int k, const int j, const int i
   CellLocation loc = DirectionToFaceID(d);
   FaceGeom g(fs.coords, fs.geom, loc, d, k, j, i);
   Real gam_max, sie_max;
-  fs.bounds->GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
+  fs.bounds.GetCeilings(g.X[1], g.X[2], g.X[3], gam_max, sie_max);
   fs.prim_to_flux(d, k, j, i, g, fs.ql, vml, vpl, Ul, Fl, sie_max, gam_max);
   fs.prim_to_flux(d, k, j, i, g, fs.qr, vmr, vpr, Ur, Fr, sie_max, gam_max);
 

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     params.Add("d.EOS", eos_device);
     params.Add("h.EOS", eos_host);
 
-    // Can specify rho_min, etc, in <eos> 
+    // Can specify rho_min, etc, in <eos>
     rho_min = pin->GetOrAddReal("eos", "rho_min", 0.0);
     sie_min = pin->GetOrAddReal("eos", "sie_min", 0.0);
     lambda[2] = {0.};

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -63,6 +63,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Real rho_max;
   Real sie_max;
   Real T_max;
+  Real ye_min;
+  Real ye_max;
 
   std::string eos_type = pin->GetString(block_name, std::string("type"));
   params.Add("type", eos_type);
@@ -89,6 +91,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     rho_max = pin->GetOrAddReal("fixup", "rho0_ceiling", 1e18);
     sie_max = pin->GetOrAddReal("fixup", "sie0_ceiling", 1e35);
     T_max = eos_host.TemperatureFromDensityInternalEnergy(rho_max, sie_max, lambda);
+    ye_min = 0.5;
+    ye_max = 0.5;
 #ifdef SPINER_USE_HDF
   } else if (eos_type == StellarCollapse::EosType()) {
     // We request that Ye and temperature exist, but do not provide them.
@@ -147,7 +151,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     T_min = eos_sc.TMin() / T_unit;
     T_max = eos_sc.TMax() / T_unit;
     rho_min = eos_sc.rhoMin() / rho_unit;
+    std::printf("rho_min code = %e\n", rho_min);
     rho_max = eos_sc.rhoMax() / rho_unit;
+    ye_min = eos_sc.YeMin();
+    ye_max = eos_sc.YeMax();
 #endif
   } else {
     std::stringstream error_mesg;
@@ -169,6 +176,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("T_max", T_max);
   params.Add("rho_min", rho_min);
   params.Add("rho_max", rho_max);
+  params.Add("ye_min", ye_min);
+  params.Add("ye_max", ye_max);
 
   return pkg;
 }

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -84,15 +84,16 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     params.Add("d.EOS", eos_device);
     params.Add("h.EOS", eos_host);
 
-    rho_min = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
-    sie_min = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
+    // Can specify rho_min, etc, in <eos> 
+    rho_min = pin->GetOrAddReal("eos", "rho_min", 0.0);
+    sie_min = pin->GetOrAddReal("eos", "sie_min", 0.0);
     lambda[2] = {0.};
     T_min = eos_host.TemperatureFromDensityInternalEnergy(rho_min, sie_min, lambda);
-    rho_max = pin->GetOrAddReal("fixup", "rho0_ceiling", 1e18);
-    sie_max = pin->GetOrAddReal("fixup", "sie0_ceiling", 1e35);
+    rho_max = pin->GetOrAddReal("eos", "rho_max", 1e18);
+    sie_max = pin->GetOrAddReal("eos", "sie_max", 1e35);
     T_max = eos_host.TemperatureFromDensityInternalEnergy(rho_max, sie_max, lambda);
-    ye_min = 0.5;
-    ye_max = 0.5;
+    ye_min = 0.01;
+    ye_max = 1.0;
 #ifdef SPINER_USE_HDF
   } else if (eos_type == StellarCollapse::EosType()) {
     // We request that Ye and temperature exist, but do not provide them.

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -151,7 +151,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     T_min = eos_sc.TMin() / T_unit;
     T_max = eos_sc.TMax() / T_unit;
     rho_min = eos_sc.rhoMin() / rho_unit;
-    std::printf("rho_min code = %e\n", rho_min);
     rho_max = eos_sc.rhoMax() / rho_unit;
     ye_min = eos_sc.YeMin();
     ye_max = eos_sc.YeMax();

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -198,9 +198,11 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real &minx_k = pmb->coords.Xf<3>(kb.s);
 
   auto coords = pmb->coords;
-  auto eos = pmb->packages.Get("eos")->Param<EOS>("d.EOS");
+  StateDescriptor *eos_pkg = pmb->packages.Get("eos").get();
+  auto eos = eos_pkg->Param<EOS>("d.EOS");
   auto eos_h = pmb->packages.Get("eos")->Param<EOS>("h.EOS");
   auto floor = pmb->packages.Get("fixup")->Param<fixup::Floors>("floor");
+  floor.SetEOSBnds(eos_pkg);
   auto &unit_conv =
       pmb->packages.Get("phoebus")->Param<phoebus::UnitConversions>("unit_conv");
   S *= unit_conv.GetEntropyCGSToCode();

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -1049,6 +1049,8 @@ void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange kb = rc->GetBoundsK(IndexDomain::interior);
 
   auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
+  auto analysis = pmb->packages.Get("analysis").get();
+  const Real sigma = analysis->Param<Real>("sigma");
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "UserWorkBeforeOutput::H5", DevExecSpace(), kb.s, kb.e, jb.s,
       jb.e, ib.s, ib.e, KOKKOS_LAMBDA(const int k, const int j, const int i) {
@@ -1071,9 +1073,7 @@ void UserWorkBeforeOutput(MeshBlock *pmb, ParameterInput *pin) {
         Real gam1[3][3];
         Real gam2[3][3];
         Real gam3[3][3];
-        auto analysis = pmb->packages.Get("analysis").get();
         const Real z = coords.Xc<3>(k, j, i);
-        const Real sigma = analysis->Param<Real>("sigma");
         const Real pi = 3.14;
         const Real s0 =
             s * std::exp(-z * z / sigma / sigma) / std::sqrt(pi) / sigma; // sigma > 0

--- a/src/radiation/moments_source.cpp
+++ b/src/radiation/moments_source.cpp
@@ -269,7 +269,7 @@ TaskStatus MomentFluidSourceImpl(T *rc, Real dt, bool update_fluid) {
     species_d[s] = species[s];
   }
 
-  auto bounds = fix_pkg->Param<fixup::Bounds>("bounds");
+  Bounds *bounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
 
   const parthenon::Coordinates_t &coords = pmb->coords;
 
@@ -315,7 +315,7 @@ TaskStatus MomentFluidSourceImpl(T *rc, Real dt, bool update_fluid) {
         // Bounds
         Real xi_max;
         Real tau_max;
-        bounds.GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+        bounds->GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
                                     coords.Xc<3>(k, j, i), xi_max, tau_max);
         const Real alpha_max = tau_max / (alpha * dt);
 

--- a/src/radiation/moments_source.cpp
+++ b/src/radiation/moments_source.cpp
@@ -269,7 +269,9 @@ TaskStatus MomentFluidSourceImpl(T *rc, Real dt, bool update_fluid) {
     species_d[s] = species[s];
   }
 
-  Bounds *bounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
+  Bounds *pbounds = fix_pkg->MutableParam<fixup::Bounds>("bounds");
+  pbounds->SetEOSBnds(eos_pkg);
+  Bounds bounds = *pbounds;
 
   const parthenon::Coordinates_t &coords = pmb->coords;
 
@@ -315,7 +317,7 @@ TaskStatus MomentFluidSourceImpl(T *rc, Real dt, bool update_fluid) {
         // Bounds
         Real xi_max;
         Real tau_max;
-        bounds->GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
+        bounds.GetRadiationCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
                                     coords.Xc<3>(k, j, i), xi_max, tau_max);
         const Real alpha_max = tau_max / (alpha * dt);
 


### PR DESCRIPTION
This PR adds knowledge of eos bounds to the floors. Specifically, for tabulated EOS, demand that the floors do not extrapolate off of the table. This required making the `bounds` param mutable.

Currently, for ideal gas, the option to enforce user set bounds is supported by supplying, e.g., `<eos>/rho_min` in the input deck. If unspecified, reasonable defaults are set.

Also fixed a misc bug in the `UserWorkBeforeOutput` code where a package and param were pulled out inside a device kernel that caused a crash on device.

