### PR TITLE
Trivial, fix: defrag_frac for tracers routines should not be int

### DIFF
--- a/doc/sphinx/src/tracers.rst
+++ b/doc/sphinx/src/tracers.rst
@@ -22,7 +22,16 @@ Tracers may be enabled by in the ``Phoebus`` input deck as follow:
 
    <tracers>
    num_tracers = 1024
+   defrag_frac = 0.2
 
+Where `<physics>/tracers = true` enables tracer particles for applicable problems, 
+`<tracers>/num_tracers` sets the number of tracer particles (usually per block), if applicable, 
+and `<tracers>/defrag_frac` sets the fractional occupancy of tracer swarm containers.
+.. note::
+   Particles typically loop from 0 to some `max_active_index`.
+   If only a small fraction of particles in that range are active, this 
+   is inefficient. `Defrag` copies active particles to a contiguous range.
+   It can be inefficient, so should be done sparingly.
 Similarly, tracers may be output by modifying an existing Parthenon output block, or creating a new one:
 
 .. code-block::

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -82,7 +82,7 @@ TaskStatus MeshReceive(MeshData<Real> *md) {
 }
 
 TaskStatus MeshDefragParticles(MeshData<Real> *md, const std::string swarm_name,
-                               const int defrag_frac) {
+                               const Real defrag_frac) {
   for (const auto &mbd : md->GetAllBlockData()) {
     auto &swarm = mbd->GetSwarmData()->Get(swarm_name);
     if (swarm->GetNumActive() > 0) {
@@ -622,7 +622,7 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
   // First order operator split tracer advection
   if (stage == integrator->nstages && tracers_active) {
     const std::string swarm_name = "tracers";
-    const int defrag_frac = 0.9; // TODO(BLB): make runtime param
+    const Real defrag_frac = 0.9; // TODO(BLB): make runtime param && ensure \in [0,1)
 
     TaskRegion &async_region_tr = tc.AddRegion(num_partitions);
     for (int n = 0; n < num_partitions; n++) {

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -622,7 +622,7 @@ TaskCollection PhoebusDriver::RungeKuttaStage(const int stage) {
   // First order operator split tracer advection
   if (stage == integrator->nstages && tracers_active) {
     const std::string swarm_name = "tracers";
-    const Real defrag_frac = 0.9; // TODO(BLB): make runtime param && ensure \in [0,1)
+    const Real defrag_frac = tracers->Param<Real>("defrag_frac");
 
     TaskRegion &async_region_tr = tc.AddRegion(num_partitions);
     for (int n = 0; n < num_partitions; n++) {

--- a/src/tracers/tracers.cpp
+++ b/src/tracers/tracers.cpp
@@ -33,6 +33,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   const int num_tracers = pin->GetOrAddInteger("tracers", "num_tracers", 0);
   params.Add("num_tracers", num_tracers);
 
+  const Real defrag_frac = pin->GetOrAddReal("tracers", "defrag_frac", 0.0);
+  PARTHENON_REQUIRE(defrag_frac >= 0.0 && defrag_frac < 1.0,
+                    "Tracer defrag fraction must be >= 0 and less than 1");
+  params.Add("defrag_frac", defrag_frac);
+
   // Initialize random number generator pool
   int rng_seed = pin->GetOrAddInteger("tracers", "rng_seed", time(NULL));
   physics->AddParam<>("rng_seed", rng_seed);


### PR DESCRIPTION
An error that slipped in through #229: `defrag_frac` for the tracer swarms defrag routines was set to an int, but should be double/Real. This is fixed. Thanks, @Yurlungur 