### PR TITLE
[trivial] fix fixup no mpi build

### DIFF
--- a/src/fixup/fixup_netfield.cpp
+++ b/src/fixup/fixup_netfield.cpp
@@ -63,6 +63,7 @@ TaskStatus SumMdotPhiForNetFieldScaling(MeshData<Real> *md, const Real t, const 
 
 TaskStatus NetFieldStartReduce(MeshData<Real> *md, const Real t, const int stage,
                                AllReduce<std::vector<Real>> *net_field_totals) {
+  using namespace parthenon;
   Mesh *pm = md->GetMeshPointer();
   StateDescriptor *fix_pkg = pm->packages.Get("fixup").get();
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When MPI is disabled, the parthenon reducers infrastructure provides MPI names. However, these are hidden in the parthenon namespace. This MR pulls out the namespace so fixup/fixup_netfield compiles when MPI is disabled. Thanks @xevra for the fix. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by calling `scripts/bash/format.sh`.
- [ ] Explain what you did.
- [ ] Make any necessary changes to the documentation.
