### PR TITLE
calculate con2prim enthalpy bound

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
           run: |
-            pip install sphinx
+            pip install "sphinx<8.2" # pinned to make multiversion work 
             pip install sphinx-sitemap
             pip install sphinx-rtd-theme
             pip install sphinx-multiversion

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -349,6 +349,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   auto eos = eos_pkg->Param<EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
+  const Real h_min = eos_pkg->Param<Real>("h_min");
 
   // BLB: Setting EOS bnds for Ceilings/Floors here.
   pbounds->SetEOSBnds(eos_pkg);
@@ -439,6 +440,8 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
           du = std::max<Real>(du, sie_floor * drho);
         }
 
+        // printf("\tfixup.cpp: %-8.5e   %-8.5e   %-8.5e   %-8.5e\n", sie_floor, u_floor_max, du, drho);
+
         Real dcrho, dS[3], dBcons[3], dtau, dyecons;
         Real bp[3] = {0};
         if (pb_hi > 0) {
@@ -469,7 +472,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
           }
 
           // fluid c2p
-          auto status = invert(geom, eos, coords, k, j, i);
+          auto status = invert(geom, eos, coords, h_min, k, j, i);
           if (status == con2prim_robust::ConToPrimStatus::failure) {
             // If fluid c2p fails, set to floors
             v(b, prho, k, j, i) = drho;

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -434,13 +434,12 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
         Real drho = rho_floor_max - v(b, prho, k, j, i);
         Real du = u_floor_max - v(b, peng, k, j, i);
-        if (drho > 0. || du > 0.) {
+
+	if (drho > 0. || du > 0.) {
           floor_applied = true;
           drho = std::max<Real>(drho, du / sie_floor);
           du = std::max<Real>(du, sie_floor * drho);
         }
-
-        // printf("\tfixup.cpp: %-8.5e   %-8.5e   %-8.5e   %-8.5e\n", sie_floor, u_floor_max, du, drho);
 
         Real dcrho, dS[3], dBcons[3], dtau, dyecons;
         Real bp[3] = {0};

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -435,7 +435,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
         Real drho = rho_floor_max - v(b, prho, k, j, i);
         Real du = u_floor_max - v(b, peng, k, j, i);
 
-	if (drho > 0. || du > 0.) {
+        if (drho > 0. || du > 0.) {
           floor_applied = true;
           drho = std::max<Real>(drho, du / sie_floor);
           du = std::max<Real>(du, sie_floor * drho);

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -45,6 +45,8 @@ struct FailFlags {
 
 class Residual {
  public:
+
+ // TODO: check if this causes compile error (leaving const variables in constructor def.)
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
            const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
@@ -57,6 +59,28 @@ class Residual {
     Real garbage = 0.0;
     bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
     bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
+
+    rho_floor_ *= floor_scale_fac_;
+  }
+
+  // NEW: overloaded constructor that handles calculation of h0sq, v0sq internally
+  KOKKOS_FUNCTION
+  Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
+           const Real rsq, const Real rbsq, const Real Ye,
+           const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
+           const Real x2, const Real x3, const Real floor_scale_fac)
+      : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq),
+        eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
+        floor_scale_fac_(floor_scale_fac) {
+
+    lambda_[0] = Ye;
+    Real garbage = 0.0;
+    bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
+    bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
+
+    h0sq_ = calc_h0sq();
+    Real zsq_ = rsq_ / h0sq_; // TODO: check that nothing breaks in this normalization.
+    v0sq_ = std::min(zsq_ / (1.0 + zsq_), 1.0 - 1.0 / (gam_max_ * gam_max_));
 
     rho_floor_ *= floor_scale_fac_;
   }
@@ -140,11 +164,18 @@ class Residual {
     return mu - muhat;
   }
 
+  // KOKKOS_INLINE_FUNCTION
+  // Real compute_upper_bound(const Real h0sq) {
+  //   auto func = [=](const Real x) { return aux_func(x, h0sq); };
+  //   root_find::RootFind root;
+  //   return root.itp(func, 1.e-16, 1.0 / sqrt(h0sq), 1.e-3, -1.0);
+  // }
+
   KOKKOS_INLINE_FUNCTION
-  Real compute_upper_bound(const Real h0sq) {
-    auto func = [=](const Real x) { return aux_func(x, h0sq); };
+  Real compute_upper_bound() {
+    auto func = [=](const Real x) { return aux_func(x); };
     root_find::RootFind root;
-    return root.itp(func, 1.e-16, 1.0 / sqrt(h0sq), 1.e-3, -1.0);
+    return root.itp(func, 1.e-16, 1.0 / sqrt(h0sq_), 1.e-3, -1.0);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -162,7 +193,9 @@ class Residual {
   }
 
  private:
-  const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_;
+  // const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_;
+  const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_;
+  Real h0sq_, v0sq_; // these cannot be const, we need to set them after initialization.
   const Microphysics::EOS::EOS &eos_;
   const fixup::Bounds bounds_;
   const Real x1_, x2_, x3_;
@@ -171,12 +204,33 @@ class Residual {
   Real rho_floor_, e_floor_, gam_max_, e_max_;
   bool used_density_floor_, used_energy_floor_, used_energy_max_, used_gamma_max_;
 
+  // KOKKOS_FORCEINLINE_FUNCTION
+  // Real aux_func(const Real mu, const Real h0sq) {
+  //   const Real x = 1.0 / (1.0 + mu * bsq_);
+  //   const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
+  //   return mu * std::sqrt(h0sq + rbarsq) - 1.0;
+  // }
+
   KOKKOS_FORCEINLINE_FUNCTION
-  Real aux_func(const Real mu, const Real h0sq) {
+  Real aux_func(const Real mu) {
     const Real x = 1.0 / (1.0 + mu * bsq_);
     const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
-    return mu * std::sqrt(h0sq + rbarsq) - 1.0;
+    return mu * std::sqrt(h0sq_ + rbarsq) - 1.0;
   }
+
+  KOKKOS_INLINE_FUNCTION
+  Real calc_h0sq() {
+    Real tmin, rhomin, epsmin, pmin, h0;
+
+    tmin = eos_.MinimumTemperature();
+    rhomin = eos_.MinimumDensity();
+    epsmin = eos_.InternalEnergyFromDensityTemperature(rhomin, tmin, lambda_);
+    pmin = eos_.PressureFromDensityTemperature(rhomin, tmin);
+  
+    h0 = 1 + epsmin + robust::ratio(pmin, rhomin); // lowest bound for enthalpy in eos at given ye
+    return h0 * h0;
+  }
+
 };
 
 template <typename T>
@@ -297,20 +351,6 @@ class ConToPrim {
   const bool fail_on_ceilings_;
 
   KOKKOS_INLINE_FUNCTION
-  Real calc_h0sq( const Microphsyics::EOS::EOS &eos, Real Ye ) {
-    Real tmin, rhomin, epsmin, pmin, h0;
-    Real eos_lambda[2] = {Ye, 0.0}; // probably shouldn't hardcode this in the future; following current method below
-
-    tmin = eos.MinimumTemperature();
-    rhomin = eos.MinimumDensity();
-    epsmin = eos.InternalEnergyFromDensityTemperature(rhomin, tmin, eos_lambda);
-    pmin = eos.PressureFromDensityTemperature(rhomin, tmin);
-  
-    h0 = 1 + epsmin + robust::ratio(pmin, rhomin); // lowest bound for enthalpy in eos at given ye
-    return h0 * h0;
-  }
-
-  KOKKOS_INLINE_FUNCTION
   ConToPrimStatus solve(const VarAccessor<T> &v, const CellGeom &g,
                         const Microphysics::EOS::EOS &eos, const Real x1, const Real x2,
                         const Real x3) const {
@@ -374,20 +414,20 @@ class ConToPrim {
       rbsq = bdotr * bdotr;
       bsq_rpsq = bsq * rsq - rbsq;
     }
-    
-    // finding a correct lower bound for enthalpy
-    h0sq_ = calc_h0sq( eos, ye_local); //TODO: check to see if this works since h0sq_ is defined as const.
 
-    const Real zsq = rsq / h0sq_;
-    Real v0sq = std::min(zsq / (1.0 + zsq), 1.0 - 1.0 / (gam_max * gam_max));
+    // const Real zsq = rsq / h0sq_; // TODO: check that nothing breaks in this normalization.
+    // Real v0sq = std::min(zsq / (1.0 + zsq), 1.0 - 1.0 / (gam_max * gam_max));
 
-    Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, ye_local, eos, bounds, x1, x2, x3,
+    // Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, ye_local, eos, bounds, x1, x2, x3,
+    //              floor_scale_fac_);
+
+    Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, ye_local, eos, bounds, x1, x2, x3,
                  floor_scale_fac_);
 
     // find the upper bound
     // TODO(JCD): revisit this.  is it worth it to find the upper bound?
     //            Doesn't seem to be at a quick glance.
-    const Real mu_r = res.compute_upper_bound(h0sq_);
+    const Real mu_r = res.compute_upper_bound();
     // solve
 
     /**

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -46,7 +46,6 @@ struct FailFlags {
 class Residual {
  public:
 
- // TODO: check if this causes compile error (leaving const variables in constructor def.)
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
            const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
@@ -164,13 +163,6 @@ class Residual {
     return mu - muhat;
   }
 
-  // KOKKOS_INLINE_FUNCTION
-  // Real compute_upper_bound(const Real h0sq) {
-  //   auto func = [=](const Real x) { return aux_func(x, h0sq); };
-  //   root_find::RootFind root;
-  //   return root.itp(func, 1.e-16, 1.0 / sqrt(h0sq), 1.e-3, -1.0);
-  // }
-
   KOKKOS_INLINE_FUNCTION
   Real compute_upper_bound() {
     auto func = [=](const Real x) { return aux_func(x); };
@@ -231,8 +223,8 @@ class Residual {
     tmin = eos_.MinimumTemperature();
     rhomin = eos_.MinimumDensity();
     epsmin = eos_.InternalEnergyFromDensityTemperature(rhomin, tmin, lambda_);
-    pmin = eos_.PressureFromDensityTemperature(rhomin, tmin);
-  
+    pmin = eos_.PressureFromDensityTemperature(rhomin, tmin, lambda_);
+
     h0 = 1 + epsmin + robust::ratio(pmin, rhomin); // lowest bound for enthalpy in eos at given ye
     return h0 * h0;
   }
@@ -420,12 +412,6 @@ class ConToPrim {
       rbsq = bdotr * bdotr;
       bsq_rpsq = bsq * rsq - rbsq;
     }
-
-    // const Real zsq = rsq / h0sq_; // TODO: check that nothing breaks in this normalization.
-    // Real v0sq = std::min(zsq / (1.0 + zsq), 1.0 - 1.0 / (gam_max * gam_max));
-
-    // Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, v0sq, ye_local, eos, bounds, x1, x2, x3,
-    //              floor_scale_fac_);
 
     Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, ye_local, eos, bounds, x1, x2, x3,
                  floor_scale_fac_);

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -46,44 +46,7 @@ struct FailFlags {
 class Residual {
  public:
 
-  // KOKKOS_FUNCTION
-  // Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
-  //          const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
-  //          const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
-  //          const Real x2, const Real x3, const Real floor_scale_fac)
-  //     : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), v0sq_(v0sq),
-  //       eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
-  //       floor_scale_fac_(floor_scale_fac) {
-  //   lambda_[0] = Ye;
-  //   Real garbage = 0.0;
-  //   bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
-  //   bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
-
-  //   rho_floor_ *= floor_scale_fac_;
-  // }
-
-  // NEW: overloaded constructor that handles calculation of h0sq, v0sq internally
-  // KOKKOS_FUNCTION
-  // Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
-  //          const Real rsq, const Real rbsq, const Real Ye,
-  //          const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
-  //          const Real x2, const Real x3, const Real floor_scale_fac)
-  //     : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq),
-  //       eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
-  //       floor_scale_fac_(floor_scale_fac) {
-
-  //   lambda_[0] = Ye;
-  //   Real garbage = 0.0;
-  //   bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
-  //   bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
-
-  //   h0sq_ = calc_h0sq();
-  //   Real zsq_ = rsq_ / h0sq_; // TODO: check that nothing breaks in this normalization.
-  //   v0sq_ = std::min(zsq_ / (1.0 + zsq_), 1.0 - 1.0 / (gam_max_ * gam_max_));
-
-  //   rho_floor_ *= floor_scale_fac_;
-  // }
-
+  // new constructor that allows for a value of h0 to be passed in
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
            const Real rsq, const Real rbsq, const Real h0, const Real Ye,
@@ -98,7 +61,7 @@ class Residual {
     bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
     bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
 
-    Real zsq_ = rsq_ / h0sq_; // TODO: check that nothing breaks in this normalization.
+    Real zsq_ = rsq_ / h0sq_; 
     v0sq_ = std::min(zsq_ / (1.0 + zsq_), 1.0 - 1.0 / (gam_max_ * gam_max_));
 
     rho_floor_ *= floor_scale_fac_;
@@ -204,14 +167,13 @@ class Residual {
             used_gamma_max_);
   }
 
-    // FOR VERBOSE TESTING ONLY
+  // new accessor for enthalpy lower bound
   KOKKOS_INLINE_FUNCTION
   Real get_h0sq() {
     return h0sq_;
   }
 
  private:
-  // const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_;
   const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_;
   Real h0sq_, v0sq_; // these cannot be const, we need to set them after initialization.
   const Microphysics::EOS::EOS &eos_;
@@ -228,49 +190,6 @@ class Residual {
     const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
     return mu * std::sqrt(h0sq_ + rbarsq) - 1.0;
   }
-
-  // KOKKOS_INLINE_FUNCTION
-  // Real calc_h0sq() { // TODO: add option here for global search or edge case...
-  //   int n; // should be set to resolve the highest dimension of the eos table, usually density.
-  //   Real T, rho, ye, dT, drho, dye; 
-  //   Real eps, P, h0;
-  //   Real lambda[2];
-
-  //   n = 250; // maybe this shouldn't be hardcoded in the future?
-  //   h0 = 1.0; // initial guess for minimum enthalpy, sufficient in ideal cases.
-
-  //   // spacing for each dimension (i.e. np.linspace)
-  //   dT = (eos_.TMax() - eos_.TMin()) / n;
-  //   drho = (eos_.rhoMax() - eos_.rhoMin()) / n;
-  //   dye = (eos_.YeMax() - eos_.YeMin()) / (n / 2); // we don't need to resolve ye as much
-
-  //   T = eos_.TMin();
-  //   rho = eos_.rhoMin();
-  //   ye = eos_.YeMin();
-    
-  //   // WIP: update this to find a global lower bound (still assuming it lies along the minimum edge of the SC-EOS table)
-  //   // realistically this should be something that happens once in something like singularity-EOS and is then callable from there...
-  //   // is there a way to refactor this to be cleaner? this is bad readability.
-    
-  //   LOOP(y, n/2) {
-  //     lambda[0] = ye;
-      
-  //     LOOP(r, n) {
-  //       LOOP(t, n) {
-
-  //           eps = eos_.InternalEnergyFromDensityTemperature(r, T, lambda);
-  //           P = eos_.PressureFromDensityTemperature(r, T, lambda);
-  //           h0 = std::min(h0, 1 + eps + robust::ratio(P, r));
-
-  //           T += dT;
-  //       }
-  //       rho += drho;
-  //     }
-  //     ye += dye;
-  //   }    
-    
-  //   return h0 * h0;
-  // }
 
 };
 
@@ -473,17 +392,12 @@ class ConToPrim {
     Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, h0, ye_local, eos, bounds, x1, x2, x3,
                  floor_scale_fac_);
 
-    // find the upper bound
-    // TODO(JCD): revisit this.  is it worth it to find the upper bound?
-    //            Doesn't seem to be at a quick glance.
-
     // conditional from Kastaun et al. 2021, we need a tighter upper bound if r > h0 due to sharp kink in lorentz factor.
     Real mu_r;
     if ( rsq >= res.get_h0sq() )
-      mu_r = res.compute_upper_bound();
+      mu_r = res.compute_upper_bound(); // we don't always need a second root find
     else
       mu_r = 1 / sqrt(res.get_h0sq());
-    // solve
 
     /**
      * TODO: implement method to find lower enthalpy bound h0 (upper root find bound) 

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -371,6 +371,17 @@ class ConToPrim {
     //            Doesn't seem to be at a quick glance.
     // const Real mu_r = res.compute_upper_bound(h0sq_);
     // solve
+
+    /**
+     * TODO: implement method to find lower enthalpy bound h0 (upper root find bound) 
+     * 
+     * Katsaun et al. 2021 only assumes h > 0, not h ≥ 1; we shouldn't have a hardcoded upper bound here.
+     * stellar collapse eos can have h < 1 due to included nuclear binding energies (e.g. Steiner et al. 
+     * 2012), this breaks our root find when mapping onto the gr grid at initialization.
+     * 
+     * can probably be resolved with an eos-conscious method using primitives (P, rho, eps) passed into here, solution tbd. 
+     */ 
+
     root_find::RootFind root(max_iter);
     const Real mu = root.regula_falsi(res, 0.0, 1.0, rel_tolerance, v(c2p_mu));
     v(c2p_mu) = mu;

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -192,6 +192,12 @@ class Residual {
             used_gamma_max_);
   }
 
+    // FOR VERBOSE TESTING ONLY
+  KOKKOS_INLINE_FUNCTION
+  Real get_h0sq() {
+    return h0sq_;
+  }
+
  private:
   // const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_, v0sq_;
   const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_;
@@ -429,6 +435,9 @@ class ConToPrim {
     //            Doesn't seem to be at a quick glance.
     const Real mu_r = res.compute_upper_bound();
     // solve
+
+    // TESTING, VERBOSE OUTPUT
+    printf("%-8.5e   %-8.5e\n", res.get_h0sq(), mu_r);
 
     /**
      * TODO: implement method to find lower enthalpy bound h0 (upper root find bound) 

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -45,15 +45,14 @@ struct FailFlags {
 
 class Residual {
  public:
-
   // new constructor that allows for a value of h0 to be passed in
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
            const Real rsq, const Real rbsq, const Real h0, const Real Ye,
            const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
            const Real x2, const Real x3, const Real floor_scale_fac)
-      : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), h0sq_(h0 * h0),
-        eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
+      : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq),
+        h0sq_(h0 * h0), eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
         floor_scale_fac_(floor_scale_fac) {
 
     lambda_[0] = Ye;
@@ -61,7 +60,7 @@ class Residual {
     bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
     bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
 
-    Real zsq_ = rsq_ / h0sq_; 
+    Real zsq_ = rsq_ / h0sq_;
     v0sq_ = std::min(zsq_ / (1.0 + zsq_), 1.0 - 1.0 / (gam_max_ * gam_max_));
 
     rho_floor_ *= floor_scale_fac_;
@@ -169,9 +168,7 @@ class Residual {
 
   // new accessor for enthalpy lower bound
   KOKKOS_INLINE_FUNCTION
-  Real get_h0sq() {
-    return h0sq_;
-  }
+  Real get_h0sq() { return h0sq_; }
 
  private:
   const Real D_, q_, bsq_, bsq_rpsq_, rsq_, rbsq_;
@@ -190,7 +187,6 @@ class Residual {
     const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
     return mu * std::sqrt(h0sq_ + rbarsq) - 1.0;
   }
-
 };
 
 template <typename T>
@@ -292,8 +288,8 @@ class ConToPrim {
   template <typename CoordinateSystem, class... Args>
   KOKKOS_INLINE_FUNCTION ConToPrimStatus operator()(const CoordinateSystem &geom,
                                                     const Microphysics::EOS::EOS &eos,
-                                                    const Coordinates_t &coords, const Real h0,
-                                                    Args &&...args) const {
+                                                    const Coordinates_t &coords,
+                                                    const Real h0, Args &&...args) const {
     VarAccessor<T> v(var, std::forward<Args>(args)...);
     CellGeom g(geom, std::forward<Args>(args)...);
     Real x1 = coords.Xc<1>(std::forward<Args>(args)...);
@@ -325,8 +321,7 @@ class ConToPrim {
 
   KOKKOS_INLINE_FUNCTION
   ConToPrimStatus solve(const VarAccessor<T> &v, const CellGeom &g,
-                        const Microphysics::EOS::EOS &eos,
-                        const Real x1, const Real x2,
+                        const Microphysics::EOS::EOS &eos, const Real x1, const Real x2,
                         const Real x3, const Real h0 = 1.0) const {
     int num_nans = std::isnan(v(crho)) + std::isnan(v(cmom_lo)) + std::isnan(v(ceng));
     if (num_nans > 0) return ConToPrimStatus::failure;
@@ -392,9 +387,10 @@ class ConToPrim {
     Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, h0, ye_local, eos, bounds, x1, x2, x3,
                  floor_scale_fac_);
 
-    // conditional from Kastaun et al. 2021, we need a tighter upper bound if r > h0 due to sharp kink in lorentz factor.
+    // conditional from Kastaun et al. 2021, we need a tighter upper bound if r > h0 due
+    // to sharp kink in lorentz factor.
     Real mu_r;
-    if ( rsq >= res.get_h0sq() )
+    if (rsq >= res.get_h0sq())
       mu_r = res.compute_upper_bound(); // we don't always need a second root find
     else
       mu_r = 1 / sqrt(res.get_h0sq());

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -399,16 +399,6 @@ class ConToPrim {
     else
       mu_r = 1 / sqrt(res.get_h0sq());
 
-    /**
-     * TODO: implement method to find lower enthalpy bound h0 (upper root find bound) 
-     * 
-     * Katsaun et al. 2021 only assumes h > 0, not h ≥ 1; we shouldn't have a hardcoded upper bound here.
-     * stellar collapse eos can have h < 1 due to included nuclear binding energies (e.g. Steiner et al. 
-     * 2012), this breaks our root find when mapping onto the gr grid at initialization.
-     * 
-     * can probably be resolved with an eos-conscious method using primitives (P, rho, eps) passed into here, solution tbd. 
-     */ 
-
     root_find::RootFind root(max_iter);
     const Real mu = root.regula_falsi(res, 0.0, mu_r, rel_tolerance, v(c2p_mu));
     v(c2p_mu) = mu;
@@ -428,8 +418,6 @@ class ConToPrim {
     if (pye > 0) eos_lambda[0] = v(pye);
     eos_lambda[1] = std::log10(v(tmp)); // initial guess
     v(peng) = res.ehat_mu(mu, qbar, rbarsq, vsq, W);
-    // TESTING, VERBOSE OUTPUT
-    printf("con2prim: %-8.5e   %-8.5e   %-8.5e   %-8.5e   %-8.5e\n", res.get_h0sq(), rsq, mu_r, v(peng), ye_local);
     v(tmp) = eos.TemperatureFromDensityInternalEnergy(v(prho), v(peng), eos_lambda);
     v(peng) *= v(prho); // conversion to u
     v(prs) = eos.PressureFromDensityTemperature(v(prho), v(tmp), eos_lambda);

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -202,13 +202,6 @@ class Residual {
   Real rho_floor_, e_floor_, gam_max_, e_max_;
   bool used_density_floor_, used_energy_floor_, used_energy_max_, used_gamma_max_;
 
-  // KOKKOS_FORCEINLINE_FUNCTION
-  // Real aux_func(const Real mu, const Real h0sq) {
-  //   const Real x = 1.0 / (1.0 + mu * bsq_);
-  //   const Real rbarsq = x * (rsq_ * x + mu * (1.0 + x) * rbsq_);
-  //   return mu * std::sqrt(h0sq + rbarsq) - 1.0;
-  // }
-
   KOKKOS_FORCEINLINE_FUNCTION
   Real aux_func(const Real mu) {
     const Real x = 1.0 / (1.0 + mu * bsq_);
@@ -419,11 +412,14 @@ class ConToPrim {
     // find the upper bound
     // TODO(JCD): revisit this.  is it worth it to find the upper bound?
     //            Doesn't seem to be at a quick glance.
-    const Real mu_r = res.compute_upper_bound();
-    // solve
 
-    // TESTING, VERBOSE OUTPUT
-    printf("%-8.5e   %-8.5e\n", res.get_h0sq(), mu_r);
+    // conditional from Kastaun et al. 2021, we need a tighter upper bound if r > h0 due to sharp kink in lorentz factor.
+    Real mu_r;
+    if ( rsq >= res.get_h0sq() )
+      mu_r = res.compute_upper_bound();
+    else
+      mu_r = 1 / sqrt(res.get_h0sq());
+    // solve
 
     /**
      * TODO: implement method to find lower enthalpy bound h0 (upper root find bound) 
@@ -454,8 +450,10 @@ class ConToPrim {
     if (pye > 0) eos_lambda[0] = v(pye);
     eos_lambda[1] = std::log10(v(tmp)); // initial guess
     v(peng) = res.ehat_mu(mu, qbar, rbarsq, vsq, W);
+    // TESTING, VERBOSE OUTPUT
+    printf("con2prim: %-8.5e   %-8.5e   %-8.5e   %-8.5e   %-8.5e\n", res.get_h0sq(), rsq, mu_r, v(peng), ye_local);
     v(tmp) = eos.TemperatureFromDensityInternalEnergy(v(prho), v(peng), eos_lambda);
-    v(peng) *= v(prho);
+    v(peng) *= v(prho); // conversion to u
     v(prs) = eos.PressureFromDensityTemperature(v(prho), v(tmp), eos_lambda);
     v(gm1) = eos.BulkModulusFromDensityTemperature(v(prho), v(tmp), eos_lambda) / v(prs);
     PARTHENON_DEBUG_REQUIRE(v(prs) > robust::SMALL(), "Pressure must be positive");

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -46,29 +46,50 @@ struct FailFlags {
 class Residual {
  public:
 
-  KOKKOS_FUNCTION
-  Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
-           const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
-           const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
-           const Real x2, const Real x3, const Real floor_scale_fac)
-      : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), v0sq_(v0sq),
-        eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
-        floor_scale_fac_(floor_scale_fac) {
-    lambda_[0] = Ye;
-    Real garbage = 0.0;
-    bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
-    bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
+  // KOKKOS_FUNCTION
+  // Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
+  //          const Real rsq, const Real rbsq, const Real v0sq, const Real Ye,
+  //          const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
+  //          const Real x2, const Real x3, const Real floor_scale_fac)
+  //     : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), v0sq_(v0sq),
+  //       eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
+  //       floor_scale_fac_(floor_scale_fac) {
+  //   lambda_[0] = Ye;
+  //   Real garbage = 0.0;
+  //   bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
+  //   bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
 
-    rho_floor_ *= floor_scale_fac_;
-  }
+  //   rho_floor_ *= floor_scale_fac_;
+  // }
 
   // NEW: overloaded constructor that handles calculation of h0sq, v0sq internally
+  // KOKKOS_FUNCTION
+  // Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
+  //          const Real rsq, const Real rbsq, const Real Ye,
+  //          const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
+  //          const Real x2, const Real x3, const Real floor_scale_fac)
+  //     : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq),
+  //       eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
+  //       floor_scale_fac_(floor_scale_fac) {
+
+  //   lambda_[0] = Ye;
+  //   Real garbage = 0.0;
+  //   bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
+  //   bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
+
+  //   h0sq_ = calc_h0sq();
+  //   Real zsq_ = rsq_ / h0sq_; // TODO: check that nothing breaks in this normalization.
+  //   v0sq_ = std::min(zsq_ / (1.0 + zsq_), 1.0 - 1.0 / (gam_max_ * gam_max_));
+
+  //   rho_floor_ *= floor_scale_fac_;
+  // }
+
   KOKKOS_FUNCTION
   Residual(const Real D, const Real q, const Real bsq, const Real bsq_rpsq,
-           const Real rsq, const Real rbsq, const Real Ye,
+           const Real rsq, const Real rbsq, const Real h0, const Real Ye,
            const Microphysics::EOS::EOS &eos, const fixup::Bounds &bnds, const Real x1,
            const Real x2, const Real x3, const Real floor_scale_fac)
-      : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq),
+      : D_(D), q_(q), bsq_(bsq), bsq_rpsq_(bsq_rpsq), rsq_(rsq), rbsq_(rbsq), h0sq_(h0 * h0),
         eos_(eos), bounds_(bnds), x1_(x1), x2_(x2), x3_(x3),
         floor_scale_fac_(floor_scale_fac) {
 
@@ -77,7 +98,6 @@ class Residual {
     bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
     bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
 
-    h0sq_ = calc_h0sq();
     Real zsq_ = rsq_ / h0sq_; // TODO: check that nothing breaks in this normalization.
     v0sq_ = std::min(zsq_ / (1.0 + zsq_), 1.0 - 1.0 / (gam_max_ * gam_max_));
 
@@ -209,18 +229,48 @@ class Residual {
     return mu * std::sqrt(h0sq_ + rbarsq) - 1.0;
   }
 
-  KOKKOS_INLINE_FUNCTION
-  Real calc_h0sq() {
-    Real tmin, rhomin, epsmin, pmin, h0;
+  // KOKKOS_INLINE_FUNCTION
+  // Real calc_h0sq() { // TODO: add option here for global search or edge case...
+  //   int n; // should be set to resolve the highest dimension of the eos table, usually density.
+  //   Real T, rho, ye, dT, drho, dye; 
+  //   Real eps, P, h0;
+  //   Real lambda[2];
 
-    tmin = eos_.MinimumTemperature();
-    rhomin = eos_.MinimumDensity();
-    epsmin = eos_.InternalEnergyFromDensityTemperature(rhomin, tmin, lambda_);
-    pmin = eos_.PressureFromDensityTemperature(rhomin, tmin, lambda_);
+  //   n = 250; // maybe this shouldn't be hardcoded in the future?
+  //   h0 = 1.0; // initial guess for minimum enthalpy, sufficient in ideal cases.
 
-    h0 = 1 + epsmin + robust::ratio(pmin, rhomin); // lowest bound for enthalpy in eos at given ye
-    return h0 * h0;
-  }
+  //   // spacing for each dimension (i.e. np.linspace)
+  //   dT = (eos_.TMax() - eos_.TMin()) / n;
+  //   drho = (eos_.rhoMax() - eos_.rhoMin()) / n;
+  //   dye = (eos_.YeMax() - eos_.YeMin()) / (n / 2); // we don't need to resolve ye as much
+
+  //   T = eos_.TMin();
+  //   rho = eos_.rhoMin();
+  //   ye = eos_.YeMin();
+    
+  //   // WIP: update this to find a global lower bound (still assuming it lies along the minimum edge of the SC-EOS table)
+  //   // realistically this should be something that happens once in something like singularity-EOS and is then callable from there...
+  //   // is there a way to refactor this to be cleaner? this is bad readability.
+    
+  //   LOOP(y, n/2) {
+  //     lambda[0] = ye;
+      
+  //     LOOP(r, n) {
+  //       LOOP(t, n) {
+
+  //           eps = eos_.InternalEnergyFromDensityTemperature(r, T, lambda);
+  //           P = eos_.PressureFromDensityTemperature(r, T, lambda);
+  //           h0 = std::min(h0, 1 + eps + robust::ratio(P, r));
+
+  //           T += dT;
+  //       }
+  //       rho += drho;
+  //     }
+  //     ye += dye;
+  //   }    
+    
+  //   return h0 * h0;
+  // }
 
 };
 
@@ -320,6 +370,19 @@ class ConToPrim {
     return solve(v, g, eos, x1, x2, x3);
   }
 
+  template <typename CoordinateSystem, class... Args>
+  KOKKOS_INLINE_FUNCTION ConToPrimStatus operator()(const CoordinateSystem &geom,
+                                                    const Microphysics::EOS::EOS &eos,
+                                                    const Coordinates_t &coords, const Real h0,
+                                                    Args &&...args) const {
+    VarAccessor<T> v(var, std::forward<Args>(args)...);
+    CellGeom g(geom, std::forward<Args>(args)...);
+    Real x1 = coords.Xc<1>(std::forward<Args>(args)...);
+    Real x2 = coords.Xc<2>(std::forward<Args>(args)...);
+    Real x3 = coords.Xc<3>(std::forward<Args>(args)...);
+    return solve(v, g, eos, x1, x2, x3, h0);
+  }
+
   int NumBlocks() { return var.GetDim(5); }
 
  private:
@@ -343,8 +406,9 @@ class ConToPrim {
 
   KOKKOS_INLINE_FUNCTION
   ConToPrimStatus solve(const VarAccessor<T> &v, const CellGeom &g,
-                        const Microphysics::EOS::EOS &eos, const Real x1, const Real x2,
-                        const Real x3) const {
+                        const Microphysics::EOS::EOS &eos,
+                        const Real x1, const Real x2,
+                        const Real x3, const Real h0 = 1.0) const {
     int num_nans = std::isnan(v(crho)) + std::isnan(v(cmom_lo)) + std::isnan(v(ceng));
     if (num_nans > 0) return ConToPrimStatus::failure;
     const Real igdet = 1.0 / g.gdet;
@@ -406,7 +470,7 @@ class ConToPrim {
       bsq_rpsq = bsq * rsq - rbsq;
     }
 
-    Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, ye_local, eos, bounds, x1, x2, x3,
+    Residual res(D, q, bsq, bsq_rpsq, rsq, rbsq, h0, ye_local, eos, bounds, x1, x2, x3,
                  floor_scale_fac_);
 
     // find the upper bound

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -390,10 +390,11 @@ class ConToPrim {
     // conditional from Kastaun et al. 2021, we need a tighter upper bound if r > h0 due
     // to sharp kink in lorentz factor.
     Real mu_r;
-    if (rsq >= res.get_h0sq())
+    if (rsq >= res.get_h0sq()) {
       mu_r = res.compute_upper_bound(); // we don't always need a second root find
-    else
+    } else {
       mu_r = 1 / sqrt(res.get_h0sq());
+    }
 
     root_find::RootFind root(max_iter);
     const Real mu = root.regula_falsi(res, 0.0, mu_r, rel_tolerance, v(c2p_mu));

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -297,6 +297,20 @@ class ConToPrim {
   const bool fail_on_ceilings_;
 
   KOKKOS_INLINE_FUNCTION
+  Real calc_h0sq( const Microphsyics::EOS::EOS &eos, Real Ye ) {
+    Real tmin, rhomin, epsmin, pmin, h0;
+    Real eos_lambda[2] = {Ye, 0.0}; // probably shouldn't hardcode this in the future; following current method below
+
+    tmin = eos.MinimumTemperature();
+    rhomin = eos.MinimumDensity();
+    epsmin = eos.InternalEnergyFromDensityTemperature(rhomin, tmin, eos_lambda);
+    pmin = eos.PressureFromDensityTemperature(rhomin, tmin);
+  
+    h0 = 1 + epsmin + robust::ratio(pmin, rhomin); // lowest bound for enthalpy in eos at given ye
+    return h0 * h0;
+  }
+
+  KOKKOS_INLINE_FUNCTION
   ConToPrimStatus solve(const VarAccessor<T> &v, const CellGeom &g,
                         const Microphysics::EOS::EOS &eos, const Real x1, const Real x2,
                         const Real x3) const {
@@ -360,6 +374,10 @@ class ConToPrim {
       rbsq = bdotr * bdotr;
       bsq_rpsq = bsq * rsq - rbsq;
     }
+    
+    // finding a correct lower bound for enthalpy
+    h0sq_ = calc_h0sq( eos, ye_local); //TODO: check to see if this works since h0sq_ is defined as const.
+
     const Real zsq = rsq / h0sq_;
     Real v0sq = std::min(zsq / (1.0 + zsq), 1.0 - 1.0 / (gam_max * gam_max));
 
@@ -369,7 +387,7 @@ class ConToPrim {
     // find the upper bound
     // TODO(JCD): revisit this.  is it worth it to find the upper bound?
     //            Doesn't seem to be at a quick glance.
-    // const Real mu_r = res.compute_upper_bound(h0sq_);
+    const Real mu_r = res.compute_upper_bound(h0sq_);
     // solve
 
     /**
@@ -383,7 +401,7 @@ class ConToPrim {
      */ 
 
     root_find::RootFind root(max_iter);
-    const Real mu = root.regula_falsi(res, 0.0, 1.0, rel_tolerance, v(c2p_mu));
+    const Real mu = root.regula_falsi(res, 0.0, mu_r, rel_tolerance, v(c2p_mu));
     v(c2p_mu) = mu;
 #if CON2PRIM_STATISTICS
     con2prim_statistics::Stats::add(root.iteration_count);

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -499,6 +499,7 @@ TaskStatus ConservedToPrimitiveRobust(T *rc, const IndexRange &ib, const IndexRa
   auto eos = eos_pkg->Param<Microphysics::EOS::EOS>("d.EOS");
   auto geom = Geometry::GetCoordinateSystem(rc);
   auto coords = pmb->coords;
+  const Real h_min = eos_pkg->Param<Real>("h_min");
 
   // TODO(JCD): move the setting of this into the solver so we can call this on MeshData
   auto fail = rc->Get(internal_variables::fail::name()).data;
@@ -507,7 +508,7 @@ TaskStatus ConservedToPrimitiveRobust(T *rc, const IndexRange &ib, const IndexRa
       DEFAULT_LOOP_PATTERN, "ConToPrim::Solve", DevExecSpace(), 0, invert.NumBlocks() - 1,
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
-        auto status = invert(geom, eos, coords, k, j, i);
+        auto status = invert(geom, eos, coords, h_min, k, j, i);
         fail(k, j, i) = (status == con2prim_robust::ConToPrimStatus::success
                              ? con2prim_robust::FailFlags::success
                              : con2prim_robust::FailFlags::fail);

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -25,6 +25,9 @@
 #include "phoebus_utils/unit_conversions.hpp"
 #include "phoebus_utils/variables.hpp"
 
+// inspired by SPACELOOP in geometry utils, util for global lower bound for enthalpy
+#define LOOP(i, n) for (int i = 0; i < n; i++)
+
 using namespace singularity;
 
 namespace Microphysics {
@@ -65,6 +68,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Real T_max;
   Real ye_min;
   Real ye_max;
+  Real h_min; // lower enthalpy bound
+  Real T, dT, rho, drho, ye, dye, eps, P; // for our bound search, temps
+  int n;
 
   std::string eos_type = pin->GetString(block_name, std::string("type"));
   params.Add("type", eos_type);
@@ -93,6 +99,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     T_max = eos_host.TemperatureFromDensityInternalEnergy(rho_max, sie_max, lambda);
     ye_min = 0.01;
     ye_max = 1.0;
+    h_min = 1.0; // is this the right guess for an ideal gas case?
+
 #ifdef SPINER_USE_HDF
   } else if (eos_type == StellarCollapse::EosType()) {
     // We request that Ye and temperature exist, but do not provide them.
@@ -154,6 +162,42 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     rho_max = eos_sc.rhoMax() / rho_unit;
     ye_min = eos_sc.YeMin();
     ye_max = eos_sc.YeMax();
+
+
+    // new calculation to find lower bound for enthalpy!
+    n = 250; // maybe this shouldn't be hardcoded in the future?
+    h_min = 1.0; // initial guess for minimum enthalpy, sufficient in ideal cases.
+    eps = 0.0;
+
+    // spacing for each dimension (i.e. np.linspace)
+    dT = (T_max - T_min) / n;
+    drho = (rho_max - rho_min) / n;
+    dye = (ye_max - ye_min) / (n / 2); // we don't need to resolve ye as much
+
+    T = T_min;
+    rho = rho_min;
+    ye = ye_min;
+    
+    // WIP: update this to find a global lower bound (still assuming it lies along the minimum edge of the SC-EOS table)
+    // realistically this should be something that happens once in something like singularity-EOS and is then callable from there...
+    // is there a way to refactor this to be cleaner? this is bad readability.
+    
+    LOOP(y, n/2) {
+      lambda[0] = ye;
+      LOOP(r, n) {
+        LOOP(t, n) {
+
+            eps = eos_sc.InternalEnergyFromDensityTemperature(rho, T, lambda) / sie_unit;
+            P = eos_sc.PressureFromDensityTemperature(rho, T, lambda) / press_unit;
+            h_min = std::min(h_min, 1 + eps + robust::ratio(P, rho));
+
+            T += dT;
+        }
+        rho += drho;
+      }
+      ye += dye;
+    }
+
 #endif
   } else {
     std::stringstream error_mesg;
@@ -166,6 +210,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     PARTHENON_THROW(error_mesg);
   }
 
+  printf("h0: %5.8e\n\n", h_min); // VERBOSE
+
   params.Add("needs_ye", needs_ye);
   params.Add("provides_entropy", provides_entropy);
 
@@ -177,6 +223,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("rho_max", rho_max);
   params.Add("ye_min", ye_min);
   params.Add("ye_max", ye_max);
+  params.Add("h_min", h_min);
 
   return pkg;
 }

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -25,9 +25,6 @@
 #include "phoebus_utils/unit_conversions.hpp"
 #include "phoebus_utils/variables.hpp"
 
-// inspired by SPACELOOP in geometry utils, util for global lower bound for enthalpy
-#define LOOP(i, n) for (int i = 0; i < n; i++)
-
 using namespace singularity;
 
 namespace Microphysics {
@@ -164,31 +161,35 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     ye_max = eos_sc.YeMax();
 
     // new calculation to find lower bound for enthalpy!
-    n = 500;     // maybe this shouldn't be hardcoded in the future?
+    n = 200;     // maybe this shouldn't be hardcoded in the future?
     h_min = 1.0; // initial guess for minimum enthalpy, sufficient in ideal cases.
     eps = 0.0;
 
-    // spacing for each dimension (i.e. np.linspace)
-    dT = (T_max - T_min) / n;
-    drho = (rho_max - rho_min) / n;
-    dye = (ye_max - ye_min) / (n / 2); // we don't need to resolve ye as much
+    // spacing for each dimension (logspace for rho, T; linspace for ye)
+    // we need to use physical (i.e. not scaled) units here for eos_sc calcs
+    dT = (log10(eos_sc.TMax()) - log10(eos_sc.TMin())) / (n - 1);
+    drho = (log10(eos_sc.rhoMax()) - log10(eos_sc.rhoMin())) / (n - 1);
+    dye = (ye_max - ye_min) / ((n / 2) - 1); // we don't need to resolve ye as much
+
     // initial conditions
-    T = T_min;
-    rho = rho_min;
+    T = eos_sc.TMin();
+    rho = eos_sc.rhoMin();
     ye = ye_min;
 
-    LOOP(y, n / 2) {
+    for (int y = 0; y < n / 2; y++) {
       lambda[0] = ye;
-      LOOP(r, n) {
-        LOOP(t, n) {
+      for (int r = 0; r < n; r++) {
+        for (int t = 0; t < n; t++) {
           eps = eos_sc.InternalEnergyFromDensityTemperature(rho, T, lambda) / sie_unit;
           P = eos_sc.PressureFromDensityTemperature(rho, T, lambda) / press_unit;
           h_min = std::min(h_min, 1 + eps + robust::ratio(P, rho));
-          T += dT;
+          T *= pow(10.0, dT); // log spacing
         }
-        rho += drho;
+        T = eos_sc.TMin();      // "reset"
+        rho *= pow(10.0, drho); // log spacing
       }
-      ye += dye;
+      rho = eos_sc.rhoMin(); // "reset"
+      ye += dye;             // linear spacing
     }
 
 #endif

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -204,8 +204,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     PARTHENON_THROW(error_mesg);
   }
 
-  printf("h0: %5.8e\n\n", h_min); // TESTING, VERBOSE
-
   params.Add("needs_ye", needs_ye);
   params.Add("provides_entropy", provides_entropy);
 

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -68,7 +68,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Real T_max;
   Real ye_min;
   Real ye_max;
-  Real h_min; // lower enthalpy bound
+  Real h_min;                             // lower enthalpy bound
   Real T, dT, rho, drho, ye, dye, eps, P; // for our bound search, temps
   int n;
 
@@ -163,9 +163,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     ye_min = eos_sc.YeMin();
     ye_max = eos_sc.YeMax();
 
-
     // new calculation to find lower bound for enthalpy!
-    n = 500; // maybe this shouldn't be hardcoded in the future?
+    n = 500;     // maybe this shouldn't be hardcoded in the future?
     h_min = 1.0; // initial guess for minimum enthalpy, sufficient in ideal cases.
     eps = 0.0;
 
@@ -177,15 +176,15 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     T = T_min;
     rho = rho_min;
     ye = ye_min;
-    
-    LOOP(y, n/2) {
+
+    LOOP(y, n / 2) {
       lambda[0] = ye;
       LOOP(r, n) {
         LOOP(t, n) {
-            eps = eos_sc.InternalEnergyFromDensityTemperature(rho, T, lambda) / sie_unit;
-            P = eos_sc.PressureFromDensityTemperature(rho, T, lambda) / press_unit;
-            h_min = std::min(h_min, 1 + eps + robust::ratio(P, rho));
-            T += dT;
+          eps = eos_sc.InternalEnergyFromDensityTemperature(rho, T, lambda) / sie_unit;
+          P = eos_sc.PressureFromDensityTemperature(rho, T, lambda) / press_unit;
+          h_min = std::min(h_min, 1 + eps + robust::ratio(P, rho));
+          T += dT;
         }
         rho += drho;
       }

--- a/src/microphysics/eos_phoebus/eos_phoebus.cpp
+++ b/src/microphysics/eos_phoebus/eos_phoebus.cpp
@@ -165,7 +165,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
 
     // new calculation to find lower bound for enthalpy!
-    n = 250; // maybe this shouldn't be hardcoded in the future?
+    n = 500; // maybe this shouldn't be hardcoded in the future?
     h_min = 1.0; // initial guess for minimum enthalpy, sufficient in ideal cases.
     eps = 0.0;
 
@@ -173,24 +173,18 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     dT = (T_max - T_min) / n;
     drho = (rho_max - rho_min) / n;
     dye = (ye_max - ye_min) / (n / 2); // we don't need to resolve ye as much
-
+    // initial conditions
     T = T_min;
     rho = rho_min;
     ye = ye_min;
-    
-    // WIP: update this to find a global lower bound (still assuming it lies along the minimum edge of the SC-EOS table)
-    // realistically this should be something that happens once in something like singularity-EOS and is then callable from there...
-    // is there a way to refactor this to be cleaner? this is bad readability.
     
     LOOP(y, n/2) {
       lambda[0] = ye;
       LOOP(r, n) {
         LOOP(t, n) {
-
             eps = eos_sc.InternalEnergyFromDensityTemperature(rho, T, lambda) / sie_unit;
             P = eos_sc.PressureFromDensityTemperature(rho, T, lambda) / press_unit;
             h_min = std::min(h_min, 1 + eps + robust::ratio(P, rho));
-
             T += dT;
         }
         rho += drho;
@@ -210,7 +204,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     PARTHENON_THROW(error_mesg);
   }
 
-  printf("h0: %5.8e\n\n", h_min); // VERBOSE
+  printf("h0: %5.8e\n\n", h_min); // TESTING, VERBOSE
 
   params.Add("needs_ye", needs_ye);
   params.Add("provides_entropy", provides_entropy);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is to address a bug I encountered when working on the CCSNe problem; the root find in `con2prim_robust.cpp` isn't bracketed when initializing to the gr grid. This occurs when using a Stellar Collapse EOS (SFHo) for a progenitor at infall.

In [Kastaun et al. 2021](10.1103/PhysRevD.103.023018) there’s a required lower bound (h0) for relativistic enthalpy (h) s.t. 0 < h0 ≤ h. This also serves as the upper bound for the unbracketed root find, i.e. root find using regula falsi from (0, 1/h0].

h0 is currently hardcoded to 1.0, which breaks our upper bound condition if  h < 1, which does happen if you’re using a StellarCollapse EOS (see fig. 1 below), espeically at Ye values that are relevant for SNe. When looking at the evolution of the root find upper bound for CCSNe progenitor, it's visible that the unbracketed root find (red dashed line) occurs when 1/h ≥ 1/h0 1 (see fig. 2 below).  

Goal is to fix with something that's eos-conscious; there's existing primitives in con2prim that should be able to calculate a reasonable bound using singularity-EOS (the existing method in `compute_upper_bound()` isn't sufficient for CCSNe problem). 

<img width="1200" height="915" alt="Unknown-1" src="https://github.com/user-attachments/assets/b3ee8816-d46b-43c8-9274-e9df9edda0aa" />

_Fig. 1._ Minimum enthalpy for the SFHo table at relevant electron fraction (Ye) range.

---
<img width="1216" height="918" alt="Unknown-2" src="https://github.com/user-attachments/assets/9a2180b6-0c3d-4fcf-b305-2e2733f4cbe1" />

_Fig. 2._ Evolution of upper bound (1/h0) for a CCSNe progenitor, with location of unbracketed root find marked in red. _h_ has been scaled so that the evolution is visible in the same range as the specific internal energy.


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by calling `scripts/bash/format.sh`.
- [ ] Explain what you did.
- [ ] Make any necessary changes to the documentation.
