### PR TITLE
fix logic for gain calculations + ye bug

### DIFF
--- a/inputs/progenitor.pin
+++ b/inputs/progenitor.pin
@@ -139,7 +139,7 @@ cfl = 0.5
 method = cooling_function
 do_lightbulb 	= true
 do_liebendorfer	= true
-do_gain_calc = false # can be true or false for lightbulb only; always false for other methods
+do_gain_calc = false # defaults to false if not set
 
 <monopole_gr>
 enabled = true

--- a/inputs/progenitor.pin
+++ b/inputs/progenitor.pin
@@ -132,7 +132,14 @@ ceiling_type = ConstantGamSie
 sie0_ceiling = 10.0;
 gam0_ceiling = 10.0;
 
-
+# rad disabled in default *.pin; see <physics> above
+# simple example for lightbulb case
+<radiation> 
+cfl = 0.5 
+method = cooling_function
+do_lightbulb 	= true
+do_liebendorfer	= true
+do_gain_calc = false # can be true or false for lightbulb only; always false for other methods
 
 <monopole_gr>
 enabled = true

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -306,8 +306,9 @@ Real CalculateMdot(MeshData<Real> *md, Real rc, bool gain) {
 
   auto rad = pmb->packages.Get("radiation").get();
   const bool rad_active = rad->Param<bool>("active");
+  const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
   bool do_gain = false;
-  if (rad_active) {
+  if (rad_active && do_gain_calc) {
     const parthenon::AllReduce<bool> *pdo_gain_reducer =
         rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");
     do_gain = pdo_gain_reducer->val;

--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -308,6 +308,7 @@ Real CalculateMdot(MeshData<Real> *md, Real rc, bool gain) {
   const bool rad_active = rad->Param<bool>("active");
   const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
   bool do_gain = false;
+
   if (rad_active && do_gain_calc) {
     const parthenon::AllReduce<bool> *pdo_gain_reducer =
         rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -451,7 +451,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
           Real vp_normalobs[3] = {0}; // Inject floors at rest in normal observer frame
           Real ye = 0.5;
           if (pye > 0) {
-            ye = v(b, cye, k, j, i);
+            ye = v(b, pye, k, j, i);
           }
           eos_lambda[0] = ye;
           Real dprs =

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -760,13 +760,7 @@ TaskListStatus PhoebusDriver::RadiationPostStep() {
 
   const auto rad_method = rad->Param<std::string>("method");
   const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
-  /**
-   * TODO: history.cpp expects the Parthenon param do_gain_reducer to be
-   * defined/initialized if radiation is active (i.e. rad = true) --> we only define this
-   * in the case of the lighbulb assumption (see below.)
-   *
-   * some fix in logic needed, tbd.
-   */
+
   if (rad_method == "cooling_function") {
     parthenon::AllReduce<bool> *pdo_gain_reducer;
     bool do_lightbulb = rad->Param<bool>("do_lightbulb");
@@ -783,17 +777,17 @@ TaskListStatus PhoebusDriver::RadiationPostStep() {
       if (do_lightbulb) {
         auto calc_tau = tl.AddTask(none, radiation::LightBulbCalcTau, sc0.get());
         if (do_gain_calc) {
-          auto check_do_gain_local = tl.AddTask(calc_tau, radiation::CheckDoGain, sc0.get(),
-                                                &(pdo_gain_reducer->val));
+          auto check_do_gain_local = tl.AddTask(calc_tau, radiation::CheckDoGain,
+                                                sc0.get(), &(pdo_gain_reducer->val));
           auto start_gain_reducer =
               (ib == 0 ? tl.AddTask(check_do_gain_local,
                                     &parthenon::AllReduce<bool>::StartReduce,
                                     pdo_gain_reducer, MPI_LOR)
-                      : none);
+                       : none);
           finish_gain_reducer =
               tl.AddTask(TaskQualifier::local_sync | TaskQualifier::once_per_region,
-                        start_gain_reducer, &parthenon::AllReduce<bool>::CheckReduce,
-                        pdo_gain_reducer);
+                         start_gain_reducer, &parthenon::AllReduce<bool>::CheckReduce,
+                         pdo_gain_reducer);
         }
       }
       auto calculate_four_force =

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -759,6 +759,7 @@ TaskListStatus PhoebusDriver::RadiationPostStep() {
   auto num_independent_task_lists = blocks.size();
 
   const auto rad_method = rad->Param<std::string>("method");
+  const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
   /**
    * TODO: history.cpp expects the Parthenon param do_gain_reducer to be
    * defined/initialized if radiation is active (i.e. rad = true) --> we only define this
@@ -769,7 +770,7 @@ TaskListStatus PhoebusDriver::RadiationPostStep() {
   if (rad_method == "cooling_function") {
     parthenon::AllReduce<bool> *pdo_gain_reducer;
     bool do_lightbulb = rad->Param<bool>("do_lightbulb");
-    if (do_lightbulb) {
+    if (do_lightbulb && do_gain_calc) {
       pdo_gain_reducer = rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");
     }
     // creating a new sync region for light bulb functions
@@ -781,17 +782,19 @@ TaskListStatus PhoebusDriver::RadiationPostStep() {
       auto finish_gain_reducer = none;
       if (do_lightbulb) {
         auto calc_tau = tl.AddTask(none, radiation::LightBulbCalcTau, sc0.get());
-        auto check_do_gain_local = tl.AddTask(calc_tau, radiation::CheckDoGain, sc0.get(),
-                                              &(pdo_gain_reducer->val));
-        auto start_gain_reducer =
-            (ib == 0 ? tl.AddTask(check_do_gain_local,
-                                  &parthenon::AllReduce<bool>::StartReduce,
-                                  pdo_gain_reducer, MPI_LOR)
-                     : none);
-        finish_gain_reducer =
-            tl.AddTask(TaskQualifier::local_sync | TaskQualifier::once_per_region,
-                       start_gain_reducer, &parthenon::AllReduce<bool>::CheckReduce,
-                       pdo_gain_reducer);
+        if (do_gain_calc) {
+          auto check_do_gain_local = tl.AddTask(calc_tau, radiation::CheckDoGain, sc0.get(),
+                                                &(pdo_gain_reducer->val));
+          auto start_gain_reducer =
+              (ib == 0 ? tl.AddTask(check_do_gain_local,
+                                    &parthenon::AllReduce<bool>::StartReduce,
+                                    pdo_gain_reducer, MPI_LOR)
+                      : none);
+          finish_gain_reducer =
+              tl.AddTask(TaskQualifier::local_sync | TaskQualifier::once_per_region,
+                        start_gain_reducer, &parthenon::AllReduce<bool>::CheckReduce,
+                        pdo_gain_reducer);
+        }
       }
       auto calculate_four_force =
           tl.AddTask(finish_gain_reducer, radiation::CoolingFunctionCalculateFourForce,

--- a/src/phoebus_driver.cpp
+++ b/src/phoebus_driver.cpp
@@ -759,6 +759,13 @@ TaskListStatus PhoebusDriver::RadiationPostStep() {
   auto num_independent_task_lists = blocks.size();
 
   const auto rad_method = rad->Param<std::string>("method");
+  /**
+   * TODO: history.cpp expects the Parthenon param do_gain_reducer to be
+   * defined/initialized if radiation is active (i.e. rad = true) --> we only define this
+   * in the case of the lighbulb assumption (see below.)
+   *
+   * some fix in logic needed, tbd.
+   */
   if (rad_method == "cooling_function") {
     parthenon::AllReduce<bool> *pdo_gain_reducer;
     bool do_lightbulb = rad->Param<bool>("do_lightbulb");

--- a/src/progenitor/progenitordata.cpp
+++ b/src/progenitor/progenitordata.cpp
@@ -156,7 +156,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   };
 
   const bool rad_active = pin->GetBoolean("physics", "rad");
-  if (rad_active) {
+  const bool do_gain_calc = pin->GetOrAddBoolean("radiation", "do_gain_calc", false);
+  if (rad_active && do_gain_calc) {
     hst_vars.emplace_back(HistoryOutputVar(HstSum, Mgain, "Mgain"));
     hst_vars.emplace_back(HistoryOutputVar(HstSum, Qgain, "total net heat"));
     hst_vars.emplace_back(HistoryOutputVar(HstSum, Mdot_gain, "Mdot gain"));

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -179,15 +179,21 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
   // Light Bulb with Liebendorfer model
   const bool do_liebendorfer = rad->Param<bool>("do_liebendorfer");
   const bool do_lightbulb = rad->Param<bool>("do_lightbulb");
+  const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
+
   if (do_lightbulb) {
 #ifdef SPINER_USE_HDF
     const Real lum = rad->Param<Real>("lum");
     auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
     singularity::StellarCollapse eos_sc =
         eos.GetUnmodifiedObject().get<singularity::StellarCollapse>();
-    const parthenon::AllReduce<bool> *pdo_gain_reducer =
-        rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");
-    const bool do_gain = pdo_gain_reducer->val;
+    
+    bool do_gain = false;
+    if (do_gain_calc) {
+	const parthenon::AllReduce<bool> *pdo_gain_reducer =
+        	rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");
+	do_gain = pdo_gain_reducer->val;
+    } 
 
     parthenon::par_for(
         DEFAULT_LOOP_PATTERN, "CoolingFunctionCalculateFourForce", DevExecSpace(), 0,

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -187,13 +187,13 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
     auto eos = pmb->packages.Get("eos")->Param<Microphysics::EOS::EOS>("d.EOS");
     singularity::StellarCollapse eos_sc =
         eos.GetUnmodifiedObject().get<singularity::StellarCollapse>();
-    
+
     bool do_gain = false;
     if (do_gain_calc) {
-	const parthenon::AllReduce<bool> *pdo_gain_reducer =
-        	rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");
-	do_gain = pdo_gain_reducer->val;
-    } 
+      const parthenon::AllReduce<bool> *pdo_gain_reducer =
+          rad->MutableParam<parthenon::AllReduce<bool>>("do_gain_reducer");
+      do_gain = pdo_gain_reducer->val;
+    }
 
     parthenon::par_for(
         DEFAULT_LOOP_PATTERN, "CoolingFunctionCalculateFourForce", DevExecSpace(), 0,

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -119,7 +119,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
   // only intitialize these if we do gain calculations; otherwise not needed!
   if (do_gain_calc) {
-    printf("do_gain_calc true\n\n");
     bool always_gain = pin->GetOrAddBoolean("radiation", "always_gain", false);
     // mutable parameter for specific gain calculations
     parthenon::AllReduce<bool> do_gain_reducer;

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -138,6 +138,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       parthenon::AllReduce<bool> do_gain_reducer;
       bool always_gain = pin->GetOrAddBoolean("radiation", "always_gain", false);
       do_gain_reducer.val = always_gain;
+      // TODO: this should also be brought out of the lightbulb-only conditional
+      // (i.e. set to false in other cases?)
       params.Add("do_gain_reducer", do_gain_reducer, true);
       params.Add("always_gain", always_gain);
     }

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -113,6 +113,21 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   bool absorption = pin->GetOrAddBoolean("radiation", "absorption", true);
   params.Add("absorption", absorption);
 
+  // initialize gain parameters from .pin, set false by default
+  bool do_gain_calc = pin->GetOrAddBoolean("radiation", "do_gain_calc", false);
+  params.Add("do_gain_calc", do_gain_calc, false);
+
+  // only intitialize these if we do gain calculations; otherwise not needed!
+  if ( do_gain_calc ) {
+    printf("do_gain_calc true\n\n");
+    bool always_gain = pin->GetOrAddBoolean("radiation", "always_gain", false);
+    // mutable parameter for specific gain calculations
+    parthenon::AllReduce<bool> do_gain_reducer;
+    do_gain_reducer.val = always_gain;
+    params.Add("do_gain_reducer", do_gain_reducer, true); 
+    params.Add("always_gain", always_gain);
+  } 
+
   bool do_lightbulb = false;
   if (method == "cooling_function") {
     const bool do_liebendorfer =
@@ -135,13 +150,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 #endif // SPINER_USE_HDF
       Metadata m({Metadata::Cell, Metadata::OneCopy});
       physics->AddField(iv::tau::name(), m);
-      parthenon::AllReduce<bool> do_gain_reducer;
-      bool always_gain = pin->GetOrAddBoolean("radiation", "always_gain", false);
-      do_gain_reducer.val = always_gain;
-      // TODO: this should also be brought out of the lightbulb-only conditional
-      // (i.e. set to false in other cases?)
-      params.Add("do_gain_reducer", do_gain_reducer, true);
-      params.Add("always_gain", always_gain);
     }
   }
 

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -118,15 +118,15 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   params.Add("do_gain_calc", do_gain_calc, false);
 
   // only intitialize these if we do gain calculations; otherwise not needed!
-  if ( do_gain_calc ) {
+  if (do_gain_calc) {
     printf("do_gain_calc true\n\n");
     bool always_gain = pin->GetOrAddBoolean("radiation", "always_gain", false);
     // mutable parameter for specific gain calculations
     parthenon::AllReduce<bool> do_gain_reducer;
     do_gain_reducer.val = always_gain;
-    params.Add("do_gain_reducer", do_gain_reducer, true); 
+    params.Add("do_gain_reducer", do_gain_reducer, true);
     params.Add("always_gain", always_gain);
-  } 
+  }
 
   bool do_lightbulb = false;
   if (method == "cooling_function") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Found a small bug when working on the CCSNe problem regarding logic for gain region calculations— if you turn radiation on (`rad = true`) and use any method other than `method = cooling_function` (e.g. lightbulb), phoebus crashes. 

Looks like the parameter `do_gain_reducer` is only initialized and defined if `do_lightbulb` is true, but `history.cpp` expects this param to exist if radiation is turned on (independent of method). @AstroBarker mentioned that most of this logic was fixed in #239 but this was an edge case that was missed. 

Currently thinking the most comprehensive fix is a param under `<radiation>` in the input files that turns gain calculations on or off (defaulting to false) so that sure relevant parameters are defined outside of the lightbulb conditionals. Suggestions for logic/implementation welcome!

**edit:** also added a small update to fix a bug in the electron fraction evolution in `src/fixup/fixup.cpp` that we found where a primitive value was being set to a conserved one instead.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
- [x] Make any necessary changes to the documentation.
