### PR TITLE
adding density-temperature floors

### DIFF
--- a/src/analysis/history.cpp
+++ b/src/analysis/history.cpp
@@ -306,7 +306,10 @@ Real CalculateMdot(MeshData<Real> *md, Real rc, bool gain) {
 
   auto rad = pmb->packages.Get("radiation").get();
   const bool rad_active = rad->Param<bool>("active");
-  const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
+  bool do_gain_calc = false; // just in case rad isn't active
+  if (rad_active) {
+    rad->Param<bool>("do_gain_calc");
+  }
   bool do_gain = false;
 
   if (rad_active && do_gain_calc) {

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -140,40 +140,40 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
       params.Add("floor", Floors(constant_rho_sie_floor_tag, rho0, sie0));
-      params.Add("is_rhoT_floor", false);
+      params.Add("is_floor_rhoT", false);
     } else if (floor_type == "ExpX1RhoSie") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "sie_exp_floor", -1.0);
       params.Add("floor", Floors(exp_x1_rho_sie_floor_tag, rho0, sie0, rp, sp));
-      params.Add("is_rhoT_floor", false);
+      params.Add("is_floor_rhoT", false);
     } else if (floor_type == "ExpX1RhoU") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(exp_x1_rho_u_floor_tag, rho0, sie0, rp, sp));
-      params.Add("is_rhoT_floor", false);
+      params.Add("is_floor_rhoT", false);
     } else if (floor_type == "X1RhoSie") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(x1_rho_sie_floor_tag, rho0, sie0, rp, sp));
-      params.Add("is_rhoT_floor", false);
+      params.Add("is_floor_rhoT", false);
     } else if (floor_type == "RRhoSie") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(r_rho_sie_floor_tag, rho0, sie0, rp, sp));
-      params.Add("is_rhoT_floor", false);
+      params.Add("is_floor_rhoT", false);
     } else if (floor_type == "ConstantRhoTemp") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real temp0 = pin->GetOrAddReal("fixup", "temp0_floor", 0.0);
       params.Add("floor", Floors(constant_rho_temp_floor_tag, rho0, temp0));
-      params.Add("is_rhoT_floor", true);
+      params.Add("is_floor_rhoT", true);
     } else {
       PARTHENON_FAIL("invalid <fixup>/floor_type input");
     }
@@ -362,7 +362,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   const Real h_min = eos_pkg->Param<Real>("h_min");
   
   // checks if we're using a non-standard floor (e.g. not rho-sie based)
-  const bool is_rhoT_floor = fix_pkg->Param<bool>("is_rhoT_floor");
+  const bool is_floor_rhoT = fix_pkg->Param<bool>("is_floor_rhoT");
 
   // BLB: Setting EOS bnds for Ceilings/Floors here.
   pbounds->SetEOSBnds(eos_pkg);
@@ -450,11 +450,11 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
         Real du = u_floor_max - v(b, peng, k, j, i);
         Real dT = T_floor_max - v(b, tmp, k, j, i);
 
-        if (drho > 0. || du > 0. && !is_rhoT_floor) {
+        if (drho > 0. || du > 0. && !is_floor_rhoT) {
           floor_applied = true;
           drho = std::max<Real>(drho, du / sie_floor);
           du = std::max<Real>(du, sie_floor * drho);
-        } else if (drho > 0. || dT > 0. && is_rhoT_floor) {
+        } else if (drho > 0. || dT > 0. && is_floor_rhoT) {
           floor_applied = true;
           // new, rho-T consistent energy density (temp floor dependent)
           du = std::max<Real>(du, eos.InternalEnergyFromDensityTemperature(

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -456,7 +456,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
           du = std::max<Real>(du, sie_floor * drho);
         } else if (drho > 0. || dT > 0. && is_floor_rhoT) {
           floor_applied = true;
-          // new, rho-T consistent energy density (temp floor dependent)
+          // rho-T consistent energy density (temp floor dependent)
           du = std::max<Real>(du, eos.InternalEnergyFromDensityTemperature(
                                       rho_floor_max, T_floor_max, eos_lambda) *
                                           rho_floor_max -

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -355,11 +355,10 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   auto geom = Geometry::GetCoordinateSystem(rc);
   Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
   const Real h_min = eos_pkg->Param<Real>("h_min");
+  
   // law. are we using a StellarCollapse EOS? that determines what floor we use later.
   const bool stellar_collapse =
-      StellarCollapse::EosType().compare(eos_pkg->Param<std::string>("type")) == 0
-          ? true
-          : false;
+      eos_pkg->Param<std::string>("type").compare("StellarCollapse") == 0 ? true : false;
 
   // BLB: Setting EOS bnds for Ceilings/Floors here.
   pbounds->SetEOSBnds(eos_pkg);
@@ -447,8 +446,6 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
         Real du = u_floor_max - v(b, peng, k, j, i);
         Real dT = T_floor_max - v(b, tmp, k, j, i);
 
-        printf("%-5.8e\t", std::max<Real>(du, sie_floor * drho));
-
         if (drho > 0. || du > 0. && !stellar_collapse) {
           floor_applied = true;
           drho = std::max<Real>(drho, du / sie_floor);
@@ -461,8 +458,6 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
                                           rho_floor_max -
                                       v(b, peng, k, j, i));
         }
-
-        printf("%-5.8e\t%-5.8e\n", du, drho);
 
         Real dcrho, dS[3], dBcons[3], dtau, dyecons;
         Real bp[3] = {0};

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -140,35 +140,40 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
       params.Add("floor", Floors(constant_rho_sie_floor_tag, rho0, sie0));
+      params.Add("is_rhoT_floor", false);
     } else if (floor_type == "ExpX1RhoSie") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "sie_exp_floor", -1.0);
       params.Add("floor", Floors(exp_x1_rho_sie_floor_tag, rho0, sie0, rp, sp));
+      params.Add("is_rhoT_floor", false);
     } else if (floor_type == "ExpX1RhoU") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(exp_x1_rho_u_floor_tag, rho0, sie0, rp, sp));
+      params.Add("is_rhoT_floor", false);
     } else if (floor_type == "X1RhoSie") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(x1_rho_sie_floor_tag, rho0, sie0, rp, sp));
+      params.Add("is_rhoT_floor", false);
     } else if (floor_type == "RRhoSie") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
       Real sie0 = pin->GetOrAddReal("fixup", "u0_floor", 0.0);
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(r_rho_sie_floor_tag, rho0, sie0, rp, sp));
+      params.Add("is_rhoT_floor", false);
     } else if (floor_type == "ConstantRhoTemp") {
       Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
-      Real sie0 = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
       Real temp0 = pin->GetOrAddReal("fixup", "temp0_floor", 0.0);
-      params.Add("floor", Floors(constant_rho_temp_floor_tag, rho0, sie0, temp0));
+      params.Add("floor", Floors(constant_rho_temp_floor_tag, rho0, temp0));
+      params.Add("is_rhoT_floor", true);
     } else {
       PARTHENON_FAIL("invalid <fixup>/floor_type input");
     }
@@ -356,9 +361,8 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
   const Real h_min = eos_pkg->Param<Real>("h_min");
   
-  // law. are we using a StellarCollapse EOS? that determines what floor we use later.
-  const bool stellar_collapse =
-      eos_pkg->Param<std::string>("type").compare("StellarCollapse") == 0 ? true : false;
+  // checks if we're using a non-standard floor (e.g. not rho-sie based)
+  const bool is_rhoT_floor = fix_pkg->Param<bool>("is_rhoT_floor");
 
   // BLB: Setting EOS bnds for Ceilings/Floors here.
   pbounds->SetEOSBnds(eos_pkg);
@@ -446,13 +450,13 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
         Real du = u_floor_max - v(b, peng, k, j, i);
         Real dT = T_floor_max - v(b, tmp, k, j, i);
 
-        if (drho > 0. || du > 0. && !stellar_collapse) {
+        if (drho > 0. || du > 0. && !is_rhoT_floor) {
           floor_applied = true;
           drho = std::max<Real>(drho, du / sie_floor);
           du = std::max<Real>(du, sie_floor * drho);
-        } else if (drho > 0. || dT > 0. && stellar_collapse) {
+        } else if (drho > 0. || dT > 0. && is_rhoT_floor) {
           floor_applied = true;
-          // new, rho-T consistent energy density (temp floor dependent?)
+          // new, rho-T consistent energy density (temp floor dependent)
           du = std::max<Real>(du, eos.InternalEnergyFromDensityTemperature(
                                       rho_floor_max, T_floor_max, eos_lambda) *
                                           rho_floor_max -

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -360,7 +360,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   auto geom = Geometry::GetCoordinateSystem(rc);
   Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
   const Real h_min = eos_pkg->Param<Real>("h_min");
-  
+
   // checks if we're using a non-standard floor (e.g. not rho-sie based)
   const bool is_floor_rhoT = fix_pkg->Param<bool>("is_floor_rhoT");
 

--- a/src/fixup/fixup.cpp
+++ b/src/fixup/fixup.cpp
@@ -164,6 +164,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       Real rp = pin->GetOrAddReal("fixup", "rho_exp_floor", -2.0);
       Real sp = pin->GetOrAddReal("fixup", "u_exp_floor", -3.0);
       params.Add("floor", Floors(r_rho_sie_floor_tag, rho0, sie0, rp, sp));
+    } else if (floor_type == "ConstantRhoTemp") {
+      Real rho0 = pin->GetOrAddReal("fixup", "rho0_floor", 0.0);
+      Real sie0 = pin->GetOrAddReal("fixup", "sie0_floor", 0.0);
+      Real temp0 = pin->GetOrAddReal("fixup", "temp0_floor", 0.0);
+      params.Add("floor", Floors(constant_rho_temp_floor_tag, rho0, sie0, temp0));
     } else {
       PARTHENON_FAIL("invalid <fixup>/floor_type input");
     }
@@ -350,6 +355,11 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
   auto geom = Geometry::GetCoordinateSystem(rc);
   Bounds *pbounds = fix_pkg->MutableParam<Bounds>("bounds");
   const Real h_min = eos_pkg->Param<Real>("h_min");
+  // law. are we using a StellarCollapse EOS? that determines what floor we use later.
+  const bool stellar_collapse =
+      StellarCollapse::EosType().compare(eos_pkg->Param<std::string>("type")) == 0
+          ? true
+          : false;
 
   // BLB: Setting EOS bnds for Ceilings/Floors here.
   pbounds->SetEOSBnds(eos_pkg);
@@ -377,9 +387,9 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
                               // finding.
         eos_lambda[1] = std::log10(v(b, tmp, k, j, i)); // use last temp as initial guess
 
-        double rho_floor, sie_floor;
+        double rho_floor, sie_floor, temp_floor;
         bounds.GetFloors(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
-                         coords.Xc<3>(k, j, i), rho_floor, sie_floor);
+                         coords.Xc<3>(k, j, i), rho_floor, sie_floor, temp_floor);
         double gamma_max, e_max;
         bounds.GetCeilings(coords.Xc<1>(k, j, i), coords.Xc<2>(k, j, i),
                            coords.Xc<3>(k, j, i), gamma_max, e_max);
@@ -396,6 +406,7 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
         Real rho_floor_max = rho_floor;
         Real u_floor_max = rho_floor * sie_floor;
+        Real T_floor_max = temp_floor;
 
         bool floor_applied = false;
         bool ceiling_applied = false;
@@ -434,12 +445,24 @@ TaskStatus ApplyFloorsImpl(T *rc, IndexDomain domain = IndexDomain::entire) {
 
         Real drho = rho_floor_max - v(b, prho, k, j, i);
         Real du = u_floor_max - v(b, peng, k, j, i);
+        Real dT = T_floor_max - v(b, tmp, k, j, i);
 
-        if (drho > 0. || du > 0.) {
+        printf("%-5.8e\t", std::max<Real>(du, sie_floor * drho));
+
+        if (drho > 0. || du > 0. && !stellar_collapse) {
           floor_applied = true;
           drho = std::max<Real>(drho, du / sie_floor);
           du = std::max<Real>(du, sie_floor * drho);
+        } else if (drho > 0. || dT > 0. && stellar_collapse) {
+          floor_applied = true;
+          // new, rho-T consistent energy density (temp floor dependent?)
+          du = std::max<Real>(du, eos.InternalEnergyFromDensityTemperature(
+                                      rho_floor_max, T_floor_max, eos_lambda) *
+                                          rho_floor_max -
+                                      v(b, peng, k, j, i));
         }
+
+        printf("%-5.8e\t%-5.8e\n", du, drho);
 
         Real dcrho, dS[3], dBcons[3], dtau, dyecons;
         Real bp[3] = {0};

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -96,8 +96,8 @@ class Floors {
   }
   Floors(RRhoSieFloor, const Real rho0, const Real sie0, const Real rp, const Real sp)
       : r0_(rho0), s0_(sie0), ralpha_(rp), salpha_(sp), floor_flag_(FloorFlag::RRhoSie) {}
-  Floors(ConstantRhoTempFloor, const Real rho0, const Real temp0)
-      : r0_(rho0), t0_(temp0), floor_flag_(FloorFlag::ConstantRhoTemp) {}
+  Floors(ConstantRhoTempFloor, const Real rho0, const Real sie0, const Real temp0)
+      : r0_(rho0), s0_(sie0), t0_(temp0), floor_flag_(FloorFlag::ConstantRhoTemp) {}
 
   KOKKOS_INLINE_FUNCTION
   void GetFloors(const Real x1, const Real x2, const Real x3, Real &rflr, Real &sflr,
@@ -146,9 +146,10 @@ class Floors {
     } break;
     case FloorFlag::ConstantRhoTemp:
       rflr = r0_;
-      sflr = sie_min_eos_;
+      sflr = s0_;
       tflr = t0_;
       rflr = std::max(rflr, rho_min_eos_);
+      sflr = std::max(sflr, sie_min_eos_);
       tflr = std::max(tflr, temp_min_eos_);
       break;
     default:

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -66,8 +66,17 @@ static struct X1RhoSieFloor {
 } x1_rho_sie_floor_tag;
 static struct RRhoSieFloor {
 } r_rho_sie_floor_tag;
+static struct ConstantRhoTempFloor {
+} constant_rho_temp_floor_tag;
 
-enum class FloorFlag { ConstantRhoSie, ExpX1RhoSie, ExpX1RhoU, X1RhoSie, RRhoSie };
+enum class FloorFlag {
+  ConstantRhoSie,
+  ExpX1RhoSie,
+  ExpX1RhoU,
+  X1RhoSie,
+  RRhoSie,
+  ConstantRhoTemp
+};
 
 class Floors {
  public:
@@ -87,10 +96,12 @@ class Floors {
   }
   Floors(RRhoSieFloor, const Real rho0, const Real sie0, const Real rp, const Real sp)
       : r0_(rho0), s0_(sie0), ralpha_(rp), salpha_(sp), floor_flag_(FloorFlag::RRhoSie) {}
+  Floors(ConstantRhoTempFloor, const Real rho0, const Real temp0)
+      : r0_(rho0), t0_(temp0), floor_flag_(FloorFlag::ConstantRhoTemp) {}
 
   KOKKOS_INLINE_FUNCTION
-  void GetFloors(const Real x1, const Real x2, const Real x3, Real &rflr,
-                 Real &sflr) const {
+  void GetFloors(const Real x1, const Real x2, const Real x3, Real &rflr, Real &sflr,
+                 Real &tflr) const {
     if (!eos_bnds_set_) {
       PARTHENON_FAIL("EOS bounds not set in floors.");
     }
@@ -101,12 +112,14 @@ class Floors {
       sflr = s0_;
       rflr = std::max(rflr, rho_min_eos_);
       sflr = std::max(sflr, sie_min_eos_);
+      tflr = 0.0;
       break;
     case FloorFlag::ExpX1RhoSie:
       rflr = r0_ * std::exp(ralpha_ * x1);
       sflr = s0_ * std::exp(salpha_ * x1);
       rflr = std::max(rflr, rho_min_eos_);
       sflr = std::max(sflr, sie_min_eos_);
+      tflr = 0.0;
       break;
     case FloorFlag::ExpX1RhoU: {
       Real scratch = r0_ * std::exp(ralpha_ * x1);
@@ -114,12 +127,14 @@ class Floors {
       rflr = scratch;
       rflr = std::max(rflr, rho_min_eos_);
       sflr = std::max(sflr, sie_min_eos_);
+      tflr = 0.0;
     } break;
     case FloorFlag::X1RhoSie:
       rflr = r0_ * std::min(1.0, std::pow(x1, ralpha_));
       sflr = s0_ * std::min(1.0, std::pow(x1, salpha_));
       rflr = std::max(rflr, rho_min_eos_);
       sflr = std::max(sflr, sie_min_eos_);
+      tflr = 0.0;
       break;
     case FloorFlag::RRhoSie: {
       Real r = std::sqrt(x1 * x1 + x2 * x2 + x3 * x3);
@@ -127,7 +142,15 @@ class Floors {
       sflr = s0_ * std::min(1.0, std::pow(r, salpha_));
       rflr = std::max(rflr, rho_min_eos_);
       sflr = std::max(sflr, sie_min_eos_);
+      tflr = 0.0;
     } break;
+    case FloorFlag::ConstantRhoTemp:
+      rflr = r0_;
+      sflr = sie_min_eos_;
+      tflr = t0_;
+      rflr = std::max(rflr, rho_min_eos_);
+      tflr = std::max(tflr, temp_min_eos_);
+      break;
     default:
       PARTHENON_FAIL("No valid floor set.");
     }
@@ -137,12 +160,13 @@ class Floors {
     if (!eos_bnds_set_) {
       rho_min_eos_ = eos_pkg->Param<Real>("rho_min");
       sie_min_eos_ = eos_pkg->Param<Real>("sie_min");
+      temp_min_eos_ = eos_pkg->Param<Real>("T_min");
       eos_bnds_set_ = true;
     }
   }
 
  private:
-  Real r0_, s0_, ralpha_, salpha_, rho_min_eos_, sie_min_eos_;
+  Real r0_, s0_, t0_, ralpha_, salpha_, rho_min_eos_, sie_min_eos_, temp_min_eos_;
   const FloorFlag floor_flag_;
   bool eos_bnds_set_;
 };

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -96,8 +96,8 @@ class Floors {
   }
   Floors(RRhoSieFloor, const Real rho0, const Real sie0, const Real rp, const Real sp)
       : r0_(rho0), s0_(sie0), ralpha_(rp), salpha_(sp), floor_flag_(FloorFlag::RRhoSie) {}
-  Floors(ConstantRhoTempFloor, const Real rho0, const Real sie0, const Real temp0)
-      : r0_(rho0), s0_(sie0), t0_(temp0), floor_flag_(FloorFlag::ConstantRhoTemp) {}
+  Floors(ConstantRhoTempFloor, const Real rho0, const Real temp0)
+      : r0_(rho0), t0_(temp0), floor_flag_(FloorFlag::ConstantRhoTemp) {}
 
   KOKKOS_INLINE_FUNCTION
   void GetFloors(const Real x1, const Real x2, const Real x3, Real &rflr, Real &sflr,
@@ -146,10 +146,9 @@ class Floors {
     } break;
     case FloorFlag::ConstantRhoTemp:
       rflr = r0_;
-      sflr = s0_;
       tflr = t0_;
       rflr = std::max(rflr, rho_min_eos_);
-      sflr = std::max(sflr, sie_min_eos_);
+      sflr = sie_min_eos_; // we still need to set a minimum energy since it's used in c2p methods
       tflr = std::max(tflr, temp_min_eos_);
       break;
     default:

--- a/src/fixup/fixup.hpp
+++ b/src/fixup/fixup.hpp
@@ -148,7 +148,7 @@ class Floors {
       rflr = r0_;
       tflr = t0_;
       rflr = std::max(rflr, rho_min_eos_);
-      sflr = sie_min_eos_; // we still need to set a minimum energy since it's used in c2p methods
+      sflr = sie_min_eos_; // we still need to set a minimum energy since it's used in c2p
       tflr = std::max(tflr, temp_min_eos_);
       break;
     default:

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -57,7 +57,7 @@ class Residual {
 
     lambda_[0] = Ye;
     Real garbage = 0.0;
-    bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage);
+    bounds_.GetFloors(x1_, x2_, x3_, rho_floor_, garbage, temp_floor_);
     bounds_.GetCeilings(x1_, x2_, x3_, gam_max_, e_max_);
 
     Real zsq_ = rsq_ / h0sq_;
@@ -105,7 +105,8 @@ class Residual {
   Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
                const Real What) {
     Real rho = rhohat_mu(robust::ratio(1.0, What));
-    bounds_.GetFloors(x1_, x2_, x3_, rho, e_floor_);
+    Real T_floor;
+    bounds_.GetFloors(x1_, x2_, x3_, rho, e_floor_, temp_floor_);
     e_floor_ *= floor_scale_fac_;
     const Real ehat_trial =
         What * (qbar - mu * rbarsq) + vhatsq * What * robust::ratio(What, 1.0 + What);
@@ -178,7 +179,7 @@ class Residual {
   const Real x1_, x2_, x3_;
   const Real floor_scale_fac_;
   Real lambda_[2];
-  Real rho_floor_, e_floor_, gam_max_, e_max_;
+  Real rho_floor_, e_floor_, temp_floor_, gam_max_, e_max_;
   bool used_density_floor_, used_energy_floor_, used_energy_max_, used_gamma_max_;
 
   KOKKOS_FORCEINLINE_FUNCTION
@@ -328,8 +329,8 @@ class ConToPrim {
     const Real igdet = 1.0 / g.gdet;
 
     Real rhoflr = 0.0;
-    Real epsflr;
-    bounds.GetFloors(x1, x2, x3, rhoflr, epsflr);
+    Real epsflr, tmpflr;
+    bounds.GetFloors(x1, x2, x3, rhoflr, epsflr, tmpflr);
     rhoflr *= floor_scale_fac_;
     epsflr *= floor_scale_fac_;
     Real gam_max, eps_max;

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -105,9 +105,13 @@ class Residual {
   Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
                const Real What) {
     Real rho = rhohat_mu(robust::ratio(1.0, What));
-    Real T_floor;
     bounds_.GetFloors(x1_, x2_, x3_, rho, e_floor_, temp_floor_);
     e_floor_ *= floor_scale_fac_;
+    Real e_floor_local_ =
+        eos_.InternalEnergyFromDensityTemperature(rho, temp_floor_, lambda_);
+    // more robust case for rho-T floors >> setting e_floor to (tigher) local minimum if
+    // needed.
+    e_floor_ = std::max(e_floor_, e_floor_local_);
     const Real ehat_trial =
         What * (qbar - mu * rbarsq) + vhatsq * What * robust::ratio(What, 1.0 + What);
     used_energy_floor_ = false;

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -104,10 +104,10 @@ class Residual {
   KOKKOS_FORCEINLINE_FUNCTION
   Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
                const Real What) {
-    Real rho = rhohat_mu(robust::ratio(1.0, What));
+    const Real rho = rhohat_mu(robust::ratio(1.0, What));
     bounds_.GetFloors(x1_, x2_, x3_, rho, e_floor_, temp_floor_);
     e_floor_ *= floor_scale_fac_;
-    Real e_floor_local_ =
+    const Real e_floor_local_ =
         eos_.InternalEnergyFromDensityTemperature(rho, temp_floor_, lambda_);
     // more robust case for rho-T floors >> setting e_floor to (tigher) local minimum if
     // needed.

--- a/src/fluid/con2prim_robust.hpp
+++ b/src/fluid/con2prim_robust.hpp
@@ -104,7 +104,7 @@ class Residual {
   KOKKOS_FORCEINLINE_FUNCTION
   Real ehat_mu(const Real mu, const Real qbar, const Real rbarsq, const Real vhatsq,
                const Real What) {
-    const Real rho = rhohat_mu(robust::ratio(1.0, What));
+    Real rho = rhohat_mu(robust::ratio(1.0, What));
     bounds_.GetFloors(x1_, x2_, x3_, rho, e_floor_, temp_floor_);
     e_floor_ *= floor_scale_fac_;
     const Real e_floor_local_ =

--- a/src/fluid/riemann.hpp
+++ b/src/fluid/riemann.hpp
@@ -90,8 +90,8 @@ class FluxState {
                     const Real sie_max, const Real gam_max) const {
     const int dir = d - 1;
     Real rho_floor = q(dir, prho, k, j, i);
-    Real sie_floor;
-    bounds.GetFloors(g.X[1], g.X[2], g.X[3], rho_floor, sie_floor);
+    Real sie_floor, temp_floor;
+    bounds.GetFloors(g.X[1], g.X[2], g.X[3], rho_floor, sie_floor, temp_floor);
     const Real rho = std::max(q(dir, prho, k, j, i), rho_floor);
     Real vpcon[] = {q(dir, pvel_lo, k, j, i), q(dir, pvel_lo + 1, k, j, i),
                     q(dir, pvel_lo + 2, k, j, i)};

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -350,18 +350,19 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         }
 
         // new conditional to handle non-standard floors (rho-T).
-        if ( is_floor_rhoT ) {
+        if (is_floor_rhoT) {
 
           v(irho, k, j, i) = v(irho, k, j, i) < rhoflr ? rhoflr : v(irho, k, j, i);
           v(itmp, k, j, i) = v(itmp, k, j, i) < tmpflr ? tmpflr : v(itmp, k, j, i);
-          v(ieng, k, j, i) = eos.InternalEnergyFromDensityTemperature( v(irho, k, j, i), v(itmp, k, j, i), lambda);
+          v(ieng, k, j, i) = eos.InternalEnergyFromDensityTemperature(
+              v(irho, k, j, i), v(itmp, k, j, i), lambda);
 
         } else { // original logic, works for all rho-sie floors.
 
           v(irho, k, j, i) = v(irho, k, j, i) < rhoflr ? rhoflr : v(irho, k, j, i);
           v(ieng, k, j, i) = v(ieng, k, j, i) / v(irho, k, j, i) < epsflr
-                                ? v(irho, k, j, i) * epsflr
-                                : v(ieng, k, j, i);
+                                 ? v(irho, k, j, i) * epsflr
+                                 : v(ieng, k, j, i);
           v(itmp, k, j, i) = eos.TemperatureFromDensityInternalEnergy(
               v(irho, k, j, i), v(ieng, k, j, i) / v(irho, k, j, i), lambda);
         }
@@ -369,8 +370,8 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
         v(iprs, k, j, i) = eos.PressureFromDensityTemperature(v(irho, k, j, i),
                                                               v(itmp, k, j, i), lambda);
         v(igm1, k, j, i) = eos.BulkModulusFromDensityTemperature(
-                              v(irho, k, j, i), v(itmp, k, j, i), lambda) /
-                          v(iprs, k, j, i);
+                               v(irho, k, j, i), v(itmp, k, j, i), lambda) /
+                           v(iprs, k, j, i);
 
         Real ucon[4] = {0};
         Real vpcon[3] = {v(ivlo, k, j, i), v(ivlo + 1, k, j, i), v(ivlo + 2, k, j, i)};

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -340,8 +340,8 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
         // fixup
         Real rhoflr = 0;
-        Real epsflr;
-        floor.GetFloors(x1v, x2v, x3, rhoflr, epsflr);
+        Real epsflr, garbage;
+        floor.GetFloors(x1v, x2v, x3, rhoflr, epsflr, garbage);
         Real lambda[2] = {Ye, 0.0};
         if (iye > 0) {
           v(iye, k, j, i) = lambda[0];

--- a/src/pgen/torus.cpp
+++ b/src/pgen/torus.cpp
@@ -340,23 +340,37 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
 
         // fixup
         Real rhoflr = 0;
-        Real epsflr, garbage;
-        floor.GetFloors(x1v, x2v, x3, rhoflr, epsflr, garbage);
+        Real epsflr, tmpflr;
+        // check floor type
+        bool is_floor_rhoT = pmb->packages.Get("fixup")->Param<bool>("is_floor_rhoT");
+        floor.GetFloors(x1v, x2v, x3, rhoflr, epsflr, tmpflr);
         Real lambda[2] = {Ye, 0.0};
         if (iye > 0) {
           v(iye, k, j, i) = lambda[0];
         }
-        v(irho, k, j, i) = v(irho, k, j, i) < rhoflr ? rhoflr : v(irho, k, j, i);
-        v(ieng, k, j, i) = v(ieng, k, j, i) / v(irho, k, j, i) < epsflr
-                               ? v(irho, k, j, i) * epsflr
-                               : v(ieng, k, j, i);
-        v(itmp, k, j, i) = eos.TemperatureFromDensityInternalEnergy(
-            v(irho, k, j, i), v(ieng, k, j, i) / v(irho, k, j, i), lambda);
+
+        // new conditional to handle non-standard floors (rho-T).
+        if ( is_floor_rhoT ) {
+
+          v(irho, k, j, i) = v(irho, k, j, i) < rhoflr ? rhoflr : v(irho, k, j, i);
+          v(itmp, k, j, i) = v(itmp, k, j, i) < tmpflr ? tmpflr : v(itmp, k, j, i);
+          v(ieng, k, j, i) = eos.InternalEnergyFromDensityTemperature( v(irho, k, j, i), v(itmp, k, j, i), lambda);
+
+        } else { // original logic, works for all rho-sie floors.
+
+          v(irho, k, j, i) = v(irho, k, j, i) < rhoflr ? rhoflr : v(irho, k, j, i);
+          v(ieng, k, j, i) = v(ieng, k, j, i) / v(irho, k, j, i) < epsflr
+                                ? v(irho, k, j, i) * epsflr
+                                : v(ieng, k, j, i);
+          v(itmp, k, j, i) = eos.TemperatureFromDensityInternalEnergy(
+              v(irho, k, j, i), v(ieng, k, j, i) / v(irho, k, j, i), lambda);
+        }
+
         v(iprs, k, j, i) = eos.PressureFromDensityTemperature(v(irho, k, j, i),
                                                               v(itmp, k, j, i), lambda);
         v(igm1, k, j, i) = eos.BulkModulusFromDensityTemperature(
-                               v(irho, k, j, i), v(itmp, k, j, i), lambda) /
-                           v(iprs, k, j, i);
+                              v(irho, k, j, i), v(itmp, k, j, i), lambda) /
+                          v(iprs, k, j, i);
 
         Real ucon[4] = {0};
         Real vpcon[3] = {v(ivlo, k, j, i), v(ivlo + 1, k, j, i), v(ivlo + 2, k, j, i)};

--- a/src/progenitor/progenitordata.cpp
+++ b/src/progenitor/progenitordata.cpp
@@ -156,11 +156,13 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   };
 
   const bool rad_active = pin->GetBoolean("physics", "rad");
-  const bool do_gain_calc = pin->GetOrAddBoolean("radiation", "do_gain_calc", false);
-  if (rad_active && do_gain_calc) {
-    hst_vars.emplace_back(HistoryOutputVar(HstSum, Mgain, "Mgain"));
-    hst_vars.emplace_back(HistoryOutputVar(HstSum, Qgain, "total net heat"));
-    hst_vars.emplace_back(HistoryOutputVar(HstSum, Mdot_gain, "Mdot gain"));
+  if (rad_active) {
+    const bool do_gain_calc = pin->GetOrAddBoolean("radiation", "do_gain_calc", false);
+    if (do_gain_calc) {
+      hst_vars.emplace_back(HistoryOutputVar(HstSum, Mgain, "Mgain"));
+      hst_vars.emplace_back(HistoryOutputVar(HstSum, Qgain, "total net heat"));
+      hst_vars.emplace_back(HistoryOutputVar(HstSum, Mdot_gain, "Mdot gain"));
+    }
   }
   params.Add(parthenon::hist_param_key, hst_vars);
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Realized on my quest to get CCSNe working in phoebus that it might be a good idea to have floors that weren't dependent on inherently negative values, e.g. negative specific internal energies from tabulated equations of state (ref. #241 for additional context).

Adding a floor that relies on constant density and temperature seemed like a reasonable step given other supernovae codes (like GR1D) and a pretty lightweight addition. This is modeled fairly closely to the current implementation of `ConstantRhoSie`, with some modifications made to quantities that are updated in `fixup.cpp` once the conditions for floors to be applied are met. Suggestions for science/implementation are welcome and appreciated!

**bonus.** also found a minor logic bug that slipped through in #243 that is now fixed (things broke for the homologous case, oops).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
- [x] Make any necessary changes to the documentation.
